### PR TITLE
fix: remove ha deprecated SUPPORT_* constants

### DIFF
--- a/custom_components/ha_blueair/fan.py
+++ b/custom_components/ha_blueair/fan.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from homeassistant.components.fan import (
     FanEntity,
-    SUPPORT_SET_SPEED,
+    FanEntityFeature.SET_SPEED,
 )
 
 from .const import DOMAIN, DATA_DEVICES, DATA_AWS_DEVICES
@@ -44,7 +44,7 @@ class BlueairFan(BlueairEntity, FanEntity):
 
     @property
     def supported_features(self) -> int:
-        return SUPPORT_SET_SPEED
+        return FanEntityFeature.SET_SPEED
 
     @property
     def is_on(self) -> int:


### PR DESCRIPTION
Updated SUPPORT_SET_SPEED to FanEntityFeature.SET_SPEED, per [Deprecating all SUPPORT_* constants](https://developers.home-assistant.io/blog/2022/04/02/support-constants-deprecation/) and logged WARNING messages:

```
Logger: homeassistant.components.fan
Source: helpers/deprecation.py:204
Integration: Fan (documentation, issues)
First occurred: **REDACTED**
Last logged: **REDACTED**

SUPPORT_SET_SPEED was used from ha_blueair, this is a deprecated constant which will be removed in HA Core 2025.1. Use FanEntityFeature.SET_SPEED instead, please create a bug report at https://github.com/dahlb/ha_blueair/issues
```