### PR TITLE
fix: BlueAirFan.async_turn_on() number of positional arguments

### DIFF
--- a/custom_components/ha_blueair/fan.py
+++ b/custom_components/ha_blueair/fan.py
@@ -72,8 +72,16 @@ class BlueairFan(BlueairEntity, FanEntity):
     async def async_turn_off(self, **kwargs: any) -> None:
         await self._device.set_fan_speed("0")
 
-    async def async_turn_on(self, **kwargs: any) -> None:
-        await self._device.set_fan_speed("2")
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: any,
+    ) -> None:
+        await self._device.set_fan_speed("1")
+        self.async_write_ha_state()
+        if percentage is not None:
+            await self.async_set_percentage(percentage=percentage)
 
     @property
     def speed_count(self) -> int:


### PR DESCRIPTION
I was setting up this integration tonight and was running into an issue turning my Classic 605 and Classic 205 devices on with the Home Assistant Service Fan: Turn On function available on a custom card. 

Looking at closed issues, my issue was basically identical to #52. Reading through the discussion, I saw @dahlb's fix in 63db8fc. I replicated this for the `BlueairFan` class with some limitations. Looking through the the [`blueair_api`](https://github.com/dahlb/blueair_api) source for non-AWS devices, it doesn't look like BlueAir returns a `running` boolean (granted I haven't poked their API manually), so I just chose the lowest available speed initially for a "toggle" action.