### PR TITLE
Fix NoneType int comparison errors for blueair i35 humidifier

### DIFF
--- a/custom_components/ha_blueair/blueair_aws_data_update_coordinator.py
+++ b/custom_components/ha_blueair/blueair_aws_data_update_coordinator.py
@@ -121,7 +121,8 @@ class BlueairAwsDataUpdateCoordinator(DataUpdateCoordinator):
     @property
     def filter_expired(self) -> bool:
         """Return the current filter status."""
-        return self.blueair_api_device.filter_usage >= 95
+        return (self.blueair_api_device.filter_usage is not None
+            and self.blueair_api_device.filter_usage >= 95)
 
     async def set_fan_speed(self, new_speed) -> None:
         self.blueair_api_device.fan_speed = new_speed


### PR DESCRIPTION
Apparently we couldn't fetch the filter_usage yet thus the property is None. But because it is apparently called by all of the actions (maybe unintionally?) all actions fail with this type error on i35. I tested with this fix fan on/off and led on off works with an i35.