### PR TITLE
chore: Use coordinator as the name for *Coordinator.

### DIFF
--- a/custom_components/ha_blueair/__init__.py
+++ b/custom_components/ha_blueair/__init__.py
@@ -81,27 +81,27 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
             region=region,
         )
 
-        def create_updaters(device):
+        def create_coordinators(device):
             return BlueairDataUpdateCoordinator(
                 hass=hass,
                 blueair_api_device=device,
             )
 
-        data[DATA_DEVICES] = list(map(create_updaters, devices))
+        data[DATA_DEVICES] = list(map(create_coordinators, devices))
 
-        for updater in data[DATA_DEVICES]:
-            await updater.async_config_entry_first_refresh()
+        for coordinator in data[DATA_DEVICES]:
+            await coordinator.async_config_entry_first_refresh()
 
-        def create_aws_updaters(device):
+        def create_aws_coordinators(device):
             return BlueairAwsDataUpdateCoordinator(
                 hass=hass,
                 blueair_api_device=device,
             )
 
-        data[DATA_AWS_DEVICES] = list(map(create_aws_updaters, aws_devices))
+        data[DATA_AWS_DEVICES] = list(map(create_aws_coordinators, aws_devices))
 
-        for updater in data[DATA_AWS_DEVICES]:
-            await updater.async_config_entry_first_refresh()
+        for coordinator in data[DATA_AWS_DEVICES]:
+            await coordinator.async_config_entry_first_refresh()
 
         hass.data[DOMAIN] = data
 

--- a/custom_components/ha_blueair/binary_sensor.py
+++ b/custom_components/ha_blueair/binary_sensor.py
@@ -20,74 +20,74 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         [FeatureEnum.CHILD_LOCK, BlueairChildLockSensor],
         [FeatureEnum.WATER_SHORTAGE, BlueairWaterShortageSensor],
     ]
-    devices: list[BlueairDataUpdateCoordinator] = hass.data[DOMAIN][DATA_DEVICES]
+    coordinators: list[BlueairDataUpdateCoordinator] = hass.data[DOMAIN][DATA_DEVICES]
     entities = []
-    for device in devices:
+    for coordinator in coordinators:
         entities.extend(
             [
-                BlueairChildLockSensor(device),
-                BlueairFilterExpiredSensor(device),
-                BlueairOnlineSensor(device),
+                BlueairChildLockSensor(coordinator),
+                BlueairFilterExpiredSensor(coordinator),
+                BlueairOnlineSensor(coordinator),
             ]
         )
     async_add_entities(entities)
 
-    aws_devices: list[BlueairAwsDataUpdateCoordinator] = hass.data[DOMAIN][
+    aws_coordinators: list[BlueairAwsDataUpdateCoordinator] = hass.data[DOMAIN][
         DATA_AWS_DEVICES
     ]
     entities = []
-    for device in aws_devices:
-        entities.append(BlueairOnlineSensor(device))
+    for coordinator in aws_coordinators:
+        entities.append(BlueairOnlineSensor(coordinator))
         for feature_class in feature_class_mapping:
-            if device.blueair_api_device.model.supports_feature(feature_class[0]):
-                entities.append(feature_class[1](device))
+            if coordinator.blueair_api_device.model.supports_feature(feature_class[0]):
+                entities.append(feature_class[1](coordinator))
     async_add_entities(entities)
 
 
 class BlueairChildLockSensor(BlueairEntity, BinarySensorEntity):
     _attr_icon = "mdi:account-child-outline"
 
-    def __init__(self, device):
-        super().__init__("Child Lock", device)
+    def __init__(self, coordinator):
+        super().__init__("Child Lock", coordinator)
 
     @property
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
-        return self._device.child_lock
+        return self.coordinator.child_lock
 
 
 class BlueairFilterExpiredSensor(BlueairEntity, BinarySensorEntity):
     _attr_icon = "mdi:air-filter"
 
-    def __init__(self, device):
+    def __init__(self, coordinator):
         """Initialize the temperature sensor."""
         self.entity_description = EntityDescription(
-            key=f"#{device.blueair_api_device.uuid}-filter-expired",
+            key=f"#{coordinator.blueair_api_device.uuid}-filter-expired",
             device_class=BinarySensorDeviceClass.PROBLEM,
         )
-        super().__init__("Filter Expiration", device)
+        super().__init__("Filter Expiration", coordinator)
 
     @property
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
-        return self._device.filter_expired
+        return self.coordinator.filter_expired
 
 
 class BlueairOnlineSensor(BlueairEntity, BinarySensorEntity):
     _attr_icon = "mdi:wifi-check"
 
-    def __init__(self, device):
+    def __init__(self, coordinator):
         """Initialize the temperature sensor."""
         self.entity_description = EntityDescription(
-            key=f"#{device.blueair_api_device.uuid}-online",
+            key=f"#{coordinator.blueair_api_device.uuid}-online",
             device_class=BinarySensorDeviceClass.CONNECTIVITY,
         )
-        super().__init__("Online", device)
+        super().__init__("Online", coordinator)
 
     @property
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
-        return self._device.online
+        return self.coordinator.online
 
     @property
     def icon(self) -> str | None:
@@ -100,14 +100,14 @@ class BlueairOnlineSensor(BlueairEntity, BinarySensorEntity):
 class BlueairWaterShortageSensor(BlueairEntity, BinarySensorEntity):
     _attr_icon = "mdi:water-alert-outline"
 
-    def __init__(self, device):
+    def __init__(self, coordinator):
         self.entity_description = EntityDescription(
-            key=f"#{device.blueair_api_device.uuid}-water-shortage",
+            key=f"#{coordinator.blueair_api_device.uuid}-water-shortage",
             device_class=BinarySensorDeviceClass.PROBLEM,
         )
-        super().__init__("Water Shortage", device)
+        super().__init__("Water Shortage", coordinator)
 
     @property
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
-        return self._device.water_shortage
+        return self.coordinator.water_shortage

--- a/custom_components/ha_blueair/diagnostics.py
+++ b/custom_components/ha_blueair/diagnostics.py
@@ -26,22 +26,22 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, config_entry: ConfigEntry
 ) -> dict[str, dict[str, Any]]:
     """Return diagnostics for a config entry."""
-    device_updaters: list[BlueairDataUpdateCoordinator] = hass.data[DOMAIN][DATA_DEVICES]
-    device_aws_updaters: list[BlueairAwsDataUpdateCoordinator] = hass.data[DOMAIN][DATA_AWS_DEVICES]
-    updaters = device_updaters + device_aws_updaters
+    device_coordinators: list[BlueairDataUpdateCoordinator] = hass.data[DOMAIN][DATA_DEVICES]
+    device_aws_coordinators: list[BlueairAwsDataUpdateCoordinator] = hass.data[DOMAIN][DATA_AWS_DEVICES]
+    coordinators = device_coordinators + device_aws_coordinators
     data = {
         "entry": async_redact_data(config_entry.as_dict(), TO_REDACT),
     }
-    for updater in updaters:
-        data[updater.blueair_api_device.mac] = updater.blueair_api_device.__repr__()
+    for coordinator in coordinators:
+        data[coordinator.blueair_api_device.mac] = coordinator.blueair_api_device.__repr__()
 
         device_registry = dr.async_get(hass)
         entity_registry = er.async_get(hass)
         hass_device = device_registry.async_get_device(
-            identifiers={(DOMAIN, updater.id)}
+            identifiers={(DOMAIN, coordinator.id)}
         )
         if hass_device is not None:
-            data[updater.blueair_api_device.mac]["device"] = {
+            data[coordinator.blueair_api_device.mac]["device"] = {
                 **async_redact_data(attr.asdict(hass_device), TO_REDACT_DEVICE),
                 "entities": {},
             }
@@ -62,7 +62,7 @@ async def async_get_config_entry_diagnostics(
                     # The context doesn't provide useful information in this case.
                     state_dict.pop("context", None)
 
-                data[updater.blueair_api_device.mac]["device"]["entities"][entity_entry.entity_id] = {
+                data[coordinator.blueair_api_device.mac]["device"]["entities"][entity_entry.entity_id] = {
                     **async_redact_data(
                         attr.asdict(
                             entity_entry,

--- a/custom_components/ha_blueair/entity.py
+++ b/custom_components/ha_blueair/entity.py
@@ -19,24 +19,24 @@ class BlueairEntity(CoordinatorEntity):
     def __init__(
         self,
         entity_type: str,
-        device: BlueairAwsDataUpdateCoordinator | BlueairDataUpdateCoordinator,
+        coordinator: BlueairAwsDataUpdateCoordinator | BlueairDataUpdateCoordinator,
         **kwargs,
     ) -> None:
-        super().__init__(device)
-        self._attr_name = f"{device.blueair_api_device.name} {entity_type}"
-        self._attr_unique_id = f"{device.blueair_api_device.uuid}_{entity_type}"
+        super().__init__(coordinator)
+        self._attr_name = f"{coordinator.blueair_api_device.name} {entity_type}"
+        self._attr_unique_id = f"{coordinator.blueair_api_device.uuid}_{entity_type}"
 
-        self._device: BlueairAwsDataUpdateCoordinator = device
+        self.coordinator: BlueairAwsDataUpdateCoordinator = coordinator
 
     @property
     def device_info(self) -> DeviceInfo:
-        connections = {(dr.CONNECTION_NETWORK_MAC, self._device.blueair_api_device.mac)}
+        connections = {(dr.CONNECTION_NETWORK_MAC, self.coordinator.blueair_api_device.mac)}
         return DeviceInfo(
             connections=connections,
-            identifiers={(DOMAIN, self._device.id)},
-            manufacturer=self._device.manufacturer,
-            model=self._device.model,
-            name=self._device.blueair_api_device.name,
+            identifiers={(DOMAIN, self.coordinator.id)},
+            manufacturer=self.coordinator.manufacturer,
+            model=self.coordinator.model,
+            name=self.coordinator.blueair_api_device.name,
         )
 
     async def async_update(self):
@@ -44,9 +44,9 @@ class BlueairEntity(CoordinatorEntity):
         if not self.enabled:
             return
 
-        await self._device.async_request_refresh()
-        self._attr_available = self._device.blueair_api_device.wifi_working
+        await self.coordinator.async_request_refresh()
+        self._attr_available = self.coordinator.blueair_api_device.wifi_working
 
     async def async_added_to_hass(self):
         """When entity is added to hass."""
-        self.async_on_remove(self._device.async_add_listener(self.async_write_ha_state))
+        self.async_on_remove(self.coordinator.async_add_listener(self.async_write_ha_state))

--- a/custom_components/ha_blueair/light.py
+++ b/custom_components/ha_blueair/light.py
@@ -16,24 +16,24 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Blueair sensors from config entry."""
-    devices: list[BlueairDataUpdateCoordinator] = hass.data[DOMAIN][DATA_DEVICES]
+    coordinators: list[BlueairDataUpdateCoordinator] = hass.data[DOMAIN][DATA_DEVICES]
     entities = []
-    for device in devices:
+    for coordinator in coordinators:
         entities.extend(
             [
-                BlueairLightEntity(device),
+                BlueairLightEntity(coordinator),
             ]
         )
     async_add_entities(entities)
 
-    aws_devices: list[BlueairDataUpdateCoordinator] = hass.data[DOMAIN][
+    aws_coordinators: list[BlueairDataUpdateCoordinator] = hass.data[DOMAIN][
         DATA_AWS_DEVICES
     ]
     entities = []
-    for device in aws_devices:
+    for coordinator in aws_coordinators:
         entities.extend(
             [
-                BlueairLightEntity(device),
+                BlueairLightEntity(coordinator),
             ]
         )
     async_add_entities(entities)
@@ -43,28 +43,28 @@ class BlueairLightEntity(BlueairEntity, LightEntity):
     _attr_color_mode = ColorMode.BRIGHTNESS
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
-    def __init__(self, device):
-        super().__init__("LED Light", device)
+    def __init__(self, coordinator):
+        super().__init__("LED Light", coordinator)
 
     @property
     def brightness(self) -> int | None:
         """Return the brightness of this light between 0..255."""
-        return round(self._device.brightness / 100 * 255.0, 0)
+        return round(self.coordinator.brightness / 100 * 255.0, 0)
 
     @property
     def is_on(self) -> bool:
         """Return True if the entity is on."""
-        return self._device.brightness != 0
+        return self.coordinator.brightness != 0
 
     async def async_turn_on(self, **kwargs):
         if ATTR_BRIGHTNESS in kwargs:
             # Convert Home Assistant brightness (0-255) to Abode brightness (0-99)
             # If 100 is sent to Abode, response is 99 causing an error
-            await self._device.set_brightness(
+            await self.coordinator.set_brightness(
                 round(kwargs[ATTR_BRIGHTNESS] * 100 / 255.0)
             )
         else:
-            await self._device.set_brightness(100)
+            await self.coordinator.set_brightness(100)
 
     async def async_turn_off(self, **kwargs):
-        await self._device.set_brightness(0)
+        await self.coordinator.set_brightness(0)

--- a/custom_components/ha_blueair/sensor.py
+++ b/custom_components/ha_blueair/sensor.py
@@ -18,29 +18,29 @@ from .entity import BlueairEntity
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Blueair sensors from config entry."""
-    devices: list[BlueairDataUpdateCoordinator] = hass.data[DOMAIN][DATA_DEVICES]
+    coordinators: list[BlueairDataUpdateCoordinator] = hass.data[DOMAIN][DATA_DEVICES]
     entities = []
-    for device in devices:
-        if device.model in ["classic_280i"]:
+    for coordinator in coordinators:
+        if coordinator.model in ["classic_280i"]:
             entities.extend(
                 [
-                    BlueairTemperatureSensor(device),
-                    BlueairHumiditySensor(device),
-                    BlueairVOCSensor(device),
-                    BlueairPM25Sensor(device),
-                    BlueairCO2Sensor(device),
+                    BlueairTemperatureSensor(coordinator),
+                    BlueairHumiditySensor(coordinator),
+                    BlueairVOCSensor(coordinator),
+                    BlueairPM25Sensor(coordinator),
+                    BlueairCO2Sensor(coordinator),
                 ]
             )
-        if device.model in ["classic_290i", "classic_480i", "classic_680i"]:
+        if coordinator.model in ["classic_290i", "classic_480i", "classic_680i"]:
             entities.extend(
                 [
-                    BlueairTemperatureSensor(device),
-                    BlueairHumiditySensor(device),
-                    BlueairVOCSensor(device),
-                    BlueairPM1Sensor(device),
-                    BlueairPM10Sensor(device),
-                    BlueairPM25Sensor(device),
-                    BlueairCO2Sensor(device),
+                    BlueairTemperatureSensor(coordinator),
+                    BlueairHumiditySensor(coordinator),
+                    BlueairVOCSensor(coordinator),
+                    BlueairPM1Sensor(coordinator),
+                    BlueairPM10Sensor(coordinator),
+                    BlueairPM25Sensor(coordinator),
+                    BlueairCO2Sensor(coordinator),
                 ]
             )
     async_add_entities(entities)
@@ -53,15 +53,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         [FeatureEnum.PM10, BlueairPM10Sensor],
         [FeatureEnum.PM25, BlueairPM25Sensor],
     ]
-    aws_devices: list[BlueairAwsDataUpdateCoordinator] = hass.data[DOMAIN][
+    aws_coordinators: list[BlueairAwsDataUpdateCoordinator] = hass.data[DOMAIN][
         DATA_AWS_DEVICES
     ]
     entities = []
 
-    for device in aws_devices:
+    for coordinator in aws_coordinators:
         for feature_class in feature_class_mapping:
-            if device.blueair_api_device.model.supports_feature(feature_class[0]):
-                entities.append(feature_class[1](device))
+            if coordinator.blueair_api_device.model.supports_feature(feature_class[0]):
+                entities.append(feature_class[1](coordinator))
     async_add_entities(entities)
 
 
@@ -71,17 +71,17 @@ class BlueairTemperatureSensor(BlueairEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
-    def __init__(self, device):
+    def __init__(self, coordinator):
         """Initialize the temperature sensor."""
-        super().__init__("Temperature", device)
+        super().__init__("Temperature", coordinator)
         self._state: float | None = None
 
     @property
     def native_value(self) -> float | None:
         """Return the current temperature."""
-        if self._device.temperature is None:
+        if self.coordinator.temperature is None:
             return None
-        return round(self._device.temperature, 1)
+        return round(self.coordinator.temperature, 1)
 
     @property
     def available(self) -> bool:
@@ -95,17 +95,17 @@ class BlueairHumiditySensor(BlueairEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.HUMIDITY
     _attr_native_unit_of_measurement = PERCENTAGE
 
-    def __init__(self, device):
+    def __init__(self, coordinator):
         """Initialize the humidity sensor."""
-        super().__init__("Humidity", device)
+        super().__init__("Humidity", coordinator)
         self._state: float | None = None
 
     @property
     def native_value(self) -> float | None:
         """Return the current humidity."""
-        if self._device.humidity is None:
+        if self.coordinator.humidity is None:
             return None
-        return round(self._device.humidity, 0)
+        return round(self.coordinator.humidity, 0)
 
     @property
     def available(self) -> bool:
@@ -119,17 +119,17 @@ class BlueairVOCSensor(BlueairEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS
     _attr_native_unit_of_measurement = CONCENTRATION_PARTS_PER_BILLION
 
-    def __init__(self, device):
+    def __init__(self, coordinator):
         """Initialize the VOC sensor."""
-        super().__init__("voc", device)
+        super().__init__("voc", coordinator)
         self._state: float | None = None
 
     @property
     def native_value(self) -> float | None:
         """Return the current voc."""
-        if self._device.voc is None:
+        if self.coordinator.voc is None:
             return None
-        return round(self._device.voc, 0)
+        return round(self.coordinator.voc, 0)
 
     @property
     def available(self) -> bool:
@@ -143,20 +143,20 @@ class BlueairPM1Sensor(BlueairEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.PM1
     _attr_native_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 
-    def __init__(self, device):
+    def __init__(self, coordinator):
         """Initialize the pm1 sensor."""
-        super().__init__("pm1", device)
+        super().__init__("pm1", coordinator)
         self._state: float | None = None
 
     @property
     def native_value(self) -> float | None:
         """Return the current pm1."""
-        if self._device.pm1 is None:
+        if self.coordinator.pm1 is None:
             return None
-        if type(self._device) is DeviceAws:
-            return int((self._device.pm1 * 100) // 132)
+        if type(self.coordinator) is DeviceAws:
+            return int((self.coordinator.pm1 * 100) // 132)
         else:
-            return int(self._device.pm1)
+            return int(self.coordinator.pm1)
 
     @property
     def available(self) -> bool:
@@ -170,20 +170,20 @@ class BlueairPM10Sensor(BlueairEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.PM10
     _attr_native_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 
-    def __init__(self, device):
+    def __init__(self, coordinator):
         """Initialize the pm10 sensor."""
-        super().__init__("pm10", device)
+        super().__init__("pm10", coordinator)
         self._state: float | None = None
 
     @property
     def native_value(self) -> float | None:
         """Return the current pm10."""
-        if self._device.pm10 is None:
+        if self.coordinator.pm10 is None:
             return None
-        if type(self._device) is DeviceAws:
-            return int((self._device.pm10 * 100) // 132)
+        if type(self.coordinator) is DeviceAws:
+            return int((self.coordinator.pm10 * 100) // 132)
         else:
-            return int(self._device.pm10)
+            return int(self.coordinator.pm10)
 
     @property
     def available(self) -> bool:
@@ -197,20 +197,20 @@ class BlueairPM25Sensor(BlueairEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.PM25
     _attr_native_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 
-    def __init__(self, device):
+    def __init__(self, coordinator):
         """Initialize the pm25 sensor."""
-        super().__init__("pm25", device)
+        super().__init__("pm25", coordinator)
         self._state: float | None = None
 
     @property
     def native_value(self) -> float | None:
         """Return the current pm25."""
-        if self._device.pm25 is None:
+        if self.coordinator.pm25 is None:
             return None
-        if type(self._device) is DeviceAws:
-            return int((self._device.pm25 * 100) // 132)
+        if type(self.coordinator) is DeviceAws:
+            return int((self.coordinator.pm25 * 100) // 132)
         else:
-            return int(self._device.pm25)
+            return int(self.coordinator.pm25)
 
     @property
     def available(self) -> bool:
@@ -224,20 +224,20 @@ class BlueairCO2Sensor(BlueairEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.CO2
     _attr_native_unit_of_measurement = CONCENTRATION_PARTS_PER_MILLION
 
-    def __init__(self, device):
+    def __init__(self, coordinator):
         """Initialize the co2 sensor."""
-        super().__init__("co2", device)
+        super().__init__("co2", coordinator)
         self._state: float | None = None
 
     @property
     def native_value(self) -> float | None:
         """Return the current co2."""
-        if self._device.co2 is None:
+        if self.coordinator.co2 is None:
             return None
-        if type(self._device) is DeviceAws:
-            return int((self._device.co2 * 100) // 132)
+        if type(self.coordinator) is DeviceAws:
+            return int((self.coordinator.co2 * 100) // 132)
         else:
-            return int(self._device.co2)
+            return int(self.coordinator.co2)
 
     @property
     def available(self) -> bool:

--- a/custom_components/ha_blueair/switch.py
+++ b/custom_components/ha_blueair/switch.py
@@ -13,26 +13,26 @@ from .entity import BlueairEntity
 
 async def async_setup_entry(hass, _config_entry, async_add_entities):
     """Set up the Blueair sensors from config entry."""
-    aws_devices: list[BlueairAwsDataUpdateCoordinator] = hass.data[DOMAIN][
+    aws_coordinators: list[BlueairAwsDataUpdateCoordinator] = hass.data[DOMAIN][
         DATA_AWS_DEVICES
     ]
     entities = []
-    for device in aws_devices:
-        if device.model == ModelEnum.HUMIDIFIER_H35I:
+    for coordinator in aws_coordinators:
+        if coordinator.model == ModelEnum.HUMIDIFIER_H35I:
             entities.extend(
                 [
-                    BlueairChildLockSwitchEntity(device),
-                    BlueairAutoFanModeSwitchEntity(device),
-                    BlueairNightModeSwitchEntity(device),
-                    BlueairWickDryModeSwitchEntity(device),
+                    BlueairChildLockSwitchEntity(coordinator),
+                    BlueairAutoFanModeSwitchEntity(coordinator),
+                    BlueairNightModeSwitchEntity(coordinator),
+                    BlueairWickDryModeSwitchEntity(coordinator),
                 ]
             )
         else:
             entities.extend(
                 [
-                    BlueairChildLockSwitchEntity(device),
-                    BlueairAutoFanModeSwitchEntity(device),
-                    BlueairNightModeSwitchEntity(device),
+                    BlueairChildLockSwitchEntity(coordinator),
+                    BlueairAutoFanModeSwitchEntity(coordinator),
+                    BlueairNightModeSwitchEntity(coordinator),
                 ]
             )
     async_add_entities(entities)
@@ -41,84 +41,84 @@ async def async_setup_entry(hass, _config_entry, async_add_entities):
 class BlueairChildLockSwitchEntity(BlueairEntity, SwitchEntity):
     _attr_device_class = SwitchDeviceClass.SWITCH
 
-    def __init__(self, device):
-        super().__init__("Child Lock", device)
+    def __init__(self, coordinator):
+        super().__init__("Child Lock", coordinator)
 
     @property
     def is_on(self) -> int | None:
-        return self._device.child_lock
+        return self.coordinator.child_lock
 
     async def async_turn_on(self, **kwargs):
-        await self._device.set_child_lock(True)
+        await self.coordinator.set_child_lock(True)
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
-        await self._device.set_child_lock(False)
+        await self.coordinator.set_child_lock(False)
         self.async_write_ha_state()
 
 
 class BlueairAutoFanModeSwitchEntity(BlueairEntity, SwitchEntity):
     _attr_device_class = SwitchDeviceClass.SWITCH
 
-    def __init__(self, device):
-        super().__init__("Auto Fan Mode", device)
+    def __init__(self, coordinator):
+        super().__init__("Auto Fan Mode", coordinator)
 
     @property
     def is_on(self) -> int | None:
-        return self._device.fan_auto_mode
+        return self.coordinator.fan_auto_mode
 
     async def async_turn_on(self, **kwargs):
-        await self._device.set_fan_auto_mode(True)
+        await self.coordinator.set_fan_auto_mode(True)
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
-        await self._device.set_fan_auto_mode(False)
+        await self.coordinator.set_fan_auto_mode(False)
         self.async_write_ha_state()
 
 
 class BlueairNightModeSwitchEntity(BlueairEntity, SwitchEntity):
     _attr_device_class = SwitchDeviceClass.SWITCH
 
-    def __init__(self, device):
-        super().__init__("Night Mode", device)
+    def __init__(self, coordinator):
+        super().__init__("Night Mode", coordinator)
 
     @property
     def is_on(self) -> bool | None:
-        return self._device.night_mode
+        return self.coordinator.night_mode
 
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return self._device.night_mode is not None
+        return self.coordinator.night_mode is not None
 
     async def async_turn_on(self, **kwargs):
-        await self._device.set_night_mode(True)
+        await self.coordinator.set_night_mode(True)
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
-        await self._device.set_night_mode(False)
+        await self.coordinator.set_night_mode(False)
         self.async_write_ha_state()
 
 
 class BlueairWickDryModeSwitchEntity(BlueairEntity, SwitchEntity):
     _attr_device_class = SwitchDeviceClass.SWITCH
 
-    def __init__(self, device):
-        super().__init__("Wick Dry Mode", device)
+    def __init__(self, coordinator):
+        super().__init__("Wick Dry Mode", coordinator)
 
     @property
     def is_on(self) -> int | None:
-        return self._device.wick_dry_mode
+        return self.coordinator.wick_dry_mode
 
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return self._device.wick_dry_mode is not None
+        return self.coordinator.wick_dry_mode is not None
 
     async def async_turn_on(self, **kwargs):
-        await self._device.set_wick_dry_mode(True)
+        await self.coordinator.set_wick_dry_mode(True)
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
-        await self._device.set_wick_dry_mode(False)
+        await self.coordinator.set_wick_dry_mode(False)
         self.async_write_ha_state()


### PR DESCRIPTION
Also removes the redundant self._device member because super().__init__()
already set self.coordinator.

The name is consistent with the naming convention from the ha developer docs:

https://developers.home-assistant.io/docs/integration_fetching_data/#coordinated-single-api-poll-for-data-for-all-entities

(also the Entity class examples appear to still use the confusing 'device' as the name of the updater; seems like coordinators were introduced after that document was written).

For the next step, I am debating whether to expose the blueair_api.*Device as coordinator.device, since adding the type annotation propagation is a lot of work with no obvious gain in neither layer cleanness or functionatliy.

But this change is large enough that I would like to file it first.