### PR TITLE
fix:Use NotImplemented to detect entity existence

### DIFF
--- a/custom_components/ha_blueair/binary_sensor.py
+++ b/custom_components/ha_blueair/binary_sensor.py
@@ -25,7 +25,7 @@ class BlueairChildLockSensor(BlueairEntity, BinarySensorEntity):
     _attr_icon = "mdi:account-child-outline"
 
     @classmethod
-    def is_supported(kls, coordinator):
+    def is_implemented(kls, coordinator):
         return coordinator.child_lock is not NotImplemented
 
     def __init__(self, coordinator):
@@ -41,7 +41,7 @@ class BlueairFilterExpiredSensor(BlueairEntity, BinarySensorEntity):
     _attr_icon = "mdi:air-filter"
 
     @classmethod
-    def is_supported(kls, coordinator):
+    def is_implemented(kls, coordinator):
         return coordinator.filter_expired is not NotImplemented
 
     def __init__(self, coordinator):
@@ -62,7 +62,7 @@ class BlueairOnlineSensor(BlueairEntity, BinarySensorEntity):
     _attr_icon = "mdi:wifi-check"
 
     @classmethod
-    def is_supported(kls, coordinator):
+    def is_implemented(kls, coordinator):
         return coordinator.online is not NotImplemented
 
     def __init__(self, coordinator):
@@ -90,7 +90,7 @@ class BlueairWaterShortageSensor(BlueairEntity, BinarySensorEntity):
     _attr_icon = "mdi:water-alert-outline"
 
     @classmethod
-    def is_supported(kls, coordinator):
+    def is_implemented(kls, coordinator):
         return coordinator.water_shortage is not NotImplemented
 
     def __init__(self, coordinator):

--- a/custom_components/ha_blueair/binary_sensor.py
+++ b/custom_components/ha_blueair/binary_sensor.py
@@ -13,7 +13,7 @@ from .entity import BlueairEntity, async_setup_entry_helper
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Blueair sensors from config entry."""
     async_setup_entry_helper(hass, config_entry, async_add_entities,
-        entity_classes[
+        entity_classes=[
             BlueairOnlineSensor,
             BlueairFilterExpiredSensor,
             BlueairChildLockSensor,

--- a/custom_components/ha_blueair/binary_sensor.py
+++ b/custom_components/ha_blueair/binary_sensor.py
@@ -6,7 +6,6 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.helpers.entity import EntityDescription
 
-from .blueair_aws_data_update_coordinator import BlueairAwsDataUpdateCoordinator
 from .entity import BlueairEntity, async_setup_entry_helper
 
 

--- a/custom_components/ha_blueair/blueair_aws_data_update_coordinator.py
+++ b/custom_components/ha_blueair/blueair_aws_data_update_coordinator.py
@@ -84,14 +84,9 @@ class BlueairAwsDataUpdateCoordinator(DataUpdateCoordinator):
             return 100
 
     @property
-    def is_on(self) -> False:
+    def is_on(self) -> bool:
         """Return the current fan state."""
         return self.blueair_api_device.running
-
-    @property
-    def fan_mode_auto(self) -> bool:
-        """Return the current fan mode."""
-        return self.blueair_api_device.fan_auto_mode
 
     @property
     def brightness(self) -> int:
@@ -126,8 +121,12 @@ class BlueairAwsDataUpdateCoordinator(DataUpdateCoordinator):
         return self.blueair_api_device.pm10
 
     @property
-    def pm25(self) -> int:
+    def pm2_5(self) -> int:
         return self.blueair_api_device.pm2_5
+
+    @property
+    def co2(self) -> int:
+        return NotImplemented
 
     @property
     def online(self) -> bool:
@@ -147,13 +146,13 @@ class BlueairAwsDataUpdateCoordinator(DataUpdateCoordinator):
 
     @property
     def filter_expired(self) -> bool:
-        """Return the current filter status."""
-        if self.blueair_api_device.filter_usage is not None:
-            return (self.blueair_api_device.filter_usage >=
-                    FILTER_EXPIRED_THRESHOLD)
-        if self.blueair_api_device.wick_usage is not None:
-            return (self.blueair_api_device.wick_usage >=
-                    FILTER_EXPIRED_THRESHOLD)
+        """Returns the current filter status."""
+        if self.blueair_api_device.filter_usage not in (NotImplemented, None):
+                return (self.blueair_api_device.filter_usage >=
+                        FILTER_EXPIRED_THRESHOLD)
+        if self.blueair_api_device.wick_usage not in (NotImplemented, None):
+                return (self.blueair_api_device.wick_usage >=
+                        FILTER_EXPIRED_THRESHOLD)
 
     async def set_fan_speed(self, new_speed) -> None:
         await self.blueair_api_device.set_fan_speed(new_speed)

--- a/custom_components/ha_blueair/blueair_aws_data_update_coordinator.py
+++ b/custom_components/ha_blueair/blueair_aws_data_update_coordinator.py
@@ -37,6 +37,7 @@ class BlueairAwsDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             await self.blueair_api_device.refresh()
             self.name = f"{DOMAIN}-{self.blueair_api_device.name}"
+            _LOGGER.info("update called, pm1=%s", self.pm1)
             return {}
         except Exception as error:
             raise UpdateFailed(error) from error
@@ -121,7 +122,8 @@ class BlueairAwsDataUpdateCoordinator(DataUpdateCoordinator):
         return self.blueair_api_device.pm10
 
     @property
-    def pm2_5(self) -> int:
+    def pm25(self) -> int:
+        # pm25 is the more common name for pm2.5.
         return self.blueair_api_device.pm2_5
 
     @property
@@ -147,11 +149,11 @@ class BlueairAwsDataUpdateCoordinator(DataUpdateCoordinator):
     @property
     def filter_expired(self) -> bool:
         """Returns the current filter status."""
-        if self.blueair_api_device.filter_usage not in (NotImplemented, None):
-                return (self.blueair_api_device.filter_usage >=
+        if self.blueair_api_device.filter_usage_percentage not in (NotImplemented, None):
+                return (self.blueair_api_device.filter_usage_percentage >=
                         FILTER_EXPIRED_THRESHOLD)
-        if self.blueair_api_device.wick_usage not in (NotImplemented, None):
-                return (self.blueair_api_device.wick_usage >=
+        if self.blueair_api_device.wick_usage_percentage not in (NotImplemented, None):
+                return (self.blueair_api_device.wick_usage_percentage >=
                         FILTER_EXPIRED_THRESHOLD)
 
     async def set_fan_speed(self, new_speed) -> None:

--- a/custom_components/ha_blueair/blueair_data_update_coordinator.py
+++ b/custom_components/ha_blueair/blueair_data_update_coordinator.py
@@ -66,38 +66,9 @@ class BlueairDataUpdateCoordinator(DataUpdateCoordinator):
         return int(self.blueair_api_device.fan_speed)
 
     @property
-    def temperature(self) -> int:
-        """Return the current fan speed."""
-        return int(self.blueair_api_device.temperature)
-
-    @property
-    def humidity(self) -> int:
-        """Return the current fan speed."""
-        return int(self.blueair_api_device.humidity)
-
-    @property
-    def voc(self) -> int:
-        """Return the current fan speed."""
-        return int(self.blueair_api_device.voc)
-
-    @property
-    def pm1(self) -> int:
-        """Return the current fan speed."""
-        return int(self.blueair_api_device.pm1)
-
-    @property
-    def pm10(self) -> int:
-        """Return the current fan speed."""
-        return int(self.blueair_api_device.pm10)
-
-    @property
-    def pm25(self) -> int:
-        """Return the current fan speed."""
-        return int(self.blueair_api_device.pm25)
-
-    @property
-    def co2(self) -> int:
-        return self.blueair_api_device.co2
+    def speed_count(self) -> int:
+        """Return the max fan speed."""
+        return 3
 
     @property
     def is_on(self) -> False:
@@ -109,14 +80,12 @@ class BlueairDataUpdateCoordinator(DataUpdateCoordinator):
     @property
     def fan_mode(self) -> str:
         """Return the current fan mode."""
+        # fan_mode appears to be unused.
         return self.blueair_api_device.mode
 
     @property
     def brightness(self) -> int:
         return self.blueair_api_device.brightness
-
-    async def set_brightness(self, brightness) -> None:
-        raise NotImplementedError()
 
     @property
     def child_lock(self) -> bool:
@@ -127,8 +96,62 @@ class BlueairDataUpdateCoordinator(DataUpdateCoordinator):
         return self.blueair_api_device.night_mode
 
     @property
+    def temperature(self) -> int:
+        if self.model not in ["classic_280i", "classic_290i", "classic_480i", "classic_680i"]:
+            return NotImplemented
+        return int(self.blueair_api_device.temperature)
+
+    @property
+    def humidity(self) -> int:
+        if self.model not in ["classic_280i", "classic_290i", "classic_480i", "classic_680i"]:
+            return NotImplemented
+        return int(self.blueair_api_device.humidity)
+
+    @property
+    def voc(self) -> int:
+        if self.model not in ["classic_280i", "classic_290i", "classic_480i", "classic_680i"]:
+            return NotImplemented
+        return int(self.blueair_api_device.voc)
+
+    @property
+    def pm1(self) -> int:
+        if self.model not in ["classic_290i", "classic_480i", "classic_680i"]:
+            return NotImplemented
+        return int(self.blueair_api_device.pm1)
+
+    @property
+    def pm10(self) -> int:
+        if self.model not in ["classic_290i", "classic_480i", "classic_680i"]:
+            return NotImplemented
+        return int(self.blueair_api_device.pm10)
+
+    @property
+    def pm2_5(self) -> int:
+        if self.model not in ["classic_280i", "classic_290i", "classic_480i", "classic_680i"]:
+            return NotImplemented
+        return int(self.blueair_api_device.pm25)
+
+    @property
+    def co2(self) -> int:
+        if self.model not in ["classic_280i", "classic_290i", "classic_480i", "classic_680i"]:
+            return NotImplemented
+        return self.blueair_api_device.co2
+
+    @property
     def online(self) -> bool:
         return self.blueair_api_device.wifi_working
+
+    @property
+    def fan_auto_mode(self) -> bool:
+        return NotImplemented
+
+    @property
+    def wick_dry_mode(self) -> bool:
+        return NotImplemented
+
+    @property
+    def water_shortage(self) -> bool:
+        return NotImplemented
 
     @property
     def filter_expired(self) -> bool:
@@ -139,3 +162,7 @@ class BlueairDataUpdateCoordinator(DataUpdateCoordinator):
         self.blueair_api_device.fan_speed = new_speed
         await self.blueair_api_device.set_fan_speed(new_speed)
         await self.async_refresh()
+
+    async def set_brightness(self, brightness) -> None:
+        raise NotImplementedError
+

--- a/custom_components/ha_blueair/blueair_data_update_coordinator.py
+++ b/custom_components/ha_blueair/blueair_data_update_coordinator.py
@@ -126,7 +126,7 @@ class BlueairDataUpdateCoordinator(DataUpdateCoordinator):
         return int(self.blueair_api_device.pm10)
 
     @property
-    def pm2_5(self) -> int:
+    def pm25(self) -> int:
         if self.model not in ["classic_280i", "classic_290i", "classic_480i", "classic_680i"]:
             return NotImplemented
         return int(self.blueair_api_device.pm25)

--- a/custom_components/ha_blueair/entity.py
+++ b/custom_components/ha_blueair/entity.py
@@ -19,7 +19,7 @@ def async_setup_entry_helper(hass, config_entry, async_add_entities, entity_clas
     entities = []
     for coordinator in coordinators:
         for kls in entity_classes:
-            if kls.is_supported(coordinator):
+            if kls.is_implemented(coordinator):
                 entities.append(kls(coordinator))
 
     async_add_entities(entities)
@@ -32,7 +32,7 @@ class BlueairEntity(CoordinatorEntity):
     _attr_should_poll = False
 
     @classmethod
-    def is_supported(kls, coordinator) -> bool:
+    def is_implemented(kls, coordinator) -> bool:
        """Returns true if the coordinator supports this entity."""
        raise NotImplementedError
 

--- a/custom_components/ha_blueair/fan.py
+++ b/custom_components/ha_blueair/fan.py
@@ -6,7 +6,7 @@ from homeassistant.components.fan import (
     FanEntityFeature,
 )
 
-from .const import DOMAIN, DATA_DEVICES, DATA_AWS_DEVICES, DEFAULT_FAN_SPEED_PERCENTAGE
+from .const import DEFAULT_FAN_SPEED_PERCENTAGE
 from .blueair_data_update_coordinator import BlueairDataUpdateCoordinator
 from .blueair_aws_data_update_coordinator import BlueairAwsDataUpdateCoordinator
 from .entity import BlueairEntity, async_setup_entry_helper

--- a/custom_components/ha_blueair/fan.py
+++ b/custom_components/ha_blueair/fan.py
@@ -25,7 +25,7 @@ class BlueairFan(BlueairEntity, FanEntity):
     """Controls Fan."""
 
     @classmethod
-    def is_supported(kls, coordinator):
+    def is_implemented(kls, coordinator):
         return isinstance(coordinator, BlueairDataUpdateCoordinator)
 
     def __init__(self, coordinator: BlueairDataUpdateCoordinator):
@@ -83,7 +83,7 @@ class BlueairAwsFan(BlueairEntity, FanEntity):
     """Controls Fan."""
 
     @classmethod
-    def is_supported(kls, coordinator):
+    def is_implemented(kls, coordinator):
         return isinstance(coordinator, BlueairAwsDataUpdateCoordinator)
 
     def __init__(self, coordinator: BlueairAwsDataUpdateCoordinator):

--- a/custom_components/ha_blueair/fan.py
+++ b/custom_components/ha_blueair/fan.py
@@ -15,7 +15,7 @@ from .entity import BlueairEntity, async_setup_entry_helper
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Blueair sensors from config entry."""
     async_setup_entry_helper(hass, config_entry, async_add_entities,
-        entity_classes[
+        entity_classes=[
             BlueairFan,
             BlueairAwsFan,
     ])

--- a/custom_components/ha_blueair/light.py
+++ b/custom_components/ha_blueair/light.py
@@ -7,41 +7,26 @@ from homeassistant.components.light import (
 )
 import logging
 
-from .const import DOMAIN, DATA_AWS_DEVICES, DATA_DEVICES
-from .blueair_data_update_coordinator import BlueairDataUpdateCoordinator
-from .entity import BlueairEntity
+from .entity import BlueairEntity, async_setup_entry_helper
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Blueair sensors from config entry."""
-    coordinators: list[BlueairDataUpdateCoordinator] = hass.data[DOMAIN][DATA_DEVICES]
-    entities = []
-    for coordinator in coordinators:
-        entities.extend(
-            [
-                BlueairLightEntity(coordinator),
-            ]
-        )
-    async_add_entities(entities)
-
-    aws_coordinators: list[BlueairDataUpdateCoordinator] = hass.data[DOMAIN][
-        DATA_AWS_DEVICES
-    ]
-    entities = []
-    for coordinator in aws_coordinators:
-        entities.extend(
-            [
-                BlueairLightEntity(coordinator),
-            ]
-        )
-    async_add_entities(entities)
+    async_setup_entry_helper(hass, config_entry, async_add_entities,
+        entity_classes[
+            BlueairLightEntry,
+    ])
 
 
 class BlueairLightEntity(BlueairEntity, LightEntity):
     _attr_color_mode = ColorMode.BRIGHTNESS
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+
+    @classmethod
+    def is_supported(kls, coordinator):
+        return coordinator.brightness is not NotImplemented
 
     def __init__(self, coordinator):
         super().__init__("LED Light", coordinator)

--- a/custom_components/ha_blueair/light.py
+++ b/custom_components/ha_blueair/light.py
@@ -15,8 +15,8 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Blueair sensors from config entry."""
     async_setup_entry_helper(hass, config_entry, async_add_entities,
-        entity_classes[
-            BlueairLightEntry,
+        entity_classes=[
+            BlueairLightEntity,
     ])
 
 

--- a/custom_components/ha_blueair/light.py
+++ b/custom_components/ha_blueair/light.py
@@ -25,7 +25,7 @@ class BlueairLightEntity(BlueairEntity, LightEntity):
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
     @classmethod
-    def is_supported(kls, coordinator):
+    def is_implemented(kls, coordinator):
         return coordinator.brightness is not NotImplemented
 
     def __init__(self, coordinator):

--- a/custom_components/ha_blueair/manifest.json
+++ b/custom_components/ha_blueair/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/dahlb/ha_blueair",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/dahlb/ha_blueair/issues",
-  "requirements": ["blueair-api==1.24.1"],
+  "requirements": ["blueair-api==1.26.0"],
   "version": "1.17.3"
 }

--- a/custom_components/ha_blueair/sensor.py
+++ b/custom_components/ha_blueair/sensor.py
@@ -18,7 +18,7 @@ from .entity import BlueairEntity, async_setup_entry_helper
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Blueair sensors from config entry."""
     async_setup_entry_helper(hass, config_entry, async_add_entities,
-        entity_classes[
+        entity_classes=[
             BlueairTemperatureSensor,
             BlueairHumiditySensor,
             BlueairVOCSensor,
@@ -178,7 +178,7 @@ class BlueairPM10Sensor(BlueairEntity, SensorEntity):
 
 
 class BlueairPM25Sensor(BlueairEntity, SensorEntity):
-    """Monitors the pm25"""
+    """Monitors the pm2.5"""
 
     _attr_device_class = SensorDeviceClass.PM25
     _attr_native_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER

--- a/custom_components/ha_blueair/sensor.py
+++ b/custom_components/ha_blueair/sensor.py
@@ -10,59 +10,24 @@ from homeassistant.const import (
 )
 from blueair_api import FeatureEnum, DeviceAws
 
-from .const import DOMAIN, DATA_DEVICES, DATA_AWS_DEVICES
 from .blueair_aws_data_update_coordinator import BlueairAwsDataUpdateCoordinator
 from .blueair_data_update_coordinator import BlueairDataUpdateCoordinator
-from .entity import BlueairEntity
+from .entity import BlueairEntity, async_setup_entry_helper
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Blueair sensors from config entry."""
-    coordinators: list[BlueairDataUpdateCoordinator] = hass.data[DOMAIN][DATA_DEVICES]
-    entities = []
-    for coordinator in coordinators:
-        if coordinator.model in ["classic_280i"]:
-            entities.extend(
-                [
-                    BlueairTemperatureSensor(coordinator),
-                    BlueairHumiditySensor(coordinator),
-                    BlueairVOCSensor(coordinator),
-                    BlueairPM25Sensor(coordinator),
-                    BlueairCO2Sensor(coordinator),
-                ]
-            )
-        if coordinator.model in ["classic_290i", "classic_480i", "classic_680i"]:
-            entities.extend(
-                [
-                    BlueairTemperatureSensor(coordinator),
-                    BlueairHumiditySensor(coordinator),
-                    BlueairVOCSensor(coordinator),
-                    BlueairPM1Sensor(coordinator),
-                    BlueairPM10Sensor(coordinator),
-                    BlueairPM25Sensor(coordinator),
-                    BlueairCO2Sensor(coordinator),
-                ]
-            )
-    async_add_entities(entities)
+    async_setup_entry_helper(hass, config_entry, async_add_entities,
+        entity_classes[
+            BlueairTemperatureSensor,
+            BlueairHumiditySensor,
+            BlueairVOCSensor,
+            BlueairCO2Sensor,
+            BlueairPM1Sensor,
+            BlueairPM10Sensor,
+            BlueairPM25Sensor,
+    ])
 
-    feature_class_mapping = [
-        [FeatureEnum.TEMPERATURE, BlueairTemperatureSensor],
-        [FeatureEnum.HUMIDITY, BlueairHumiditySensor],
-        [FeatureEnum.VOC, BlueairVOCSensor],
-        [FeatureEnum.PM1, BlueairPM1Sensor],
-        [FeatureEnum.PM10, BlueairPM10Sensor],
-        [FeatureEnum.PM25, BlueairPM25Sensor],
-    ]
-    aws_coordinators: list[BlueairAwsDataUpdateCoordinator] = hass.data[DOMAIN][
-        DATA_AWS_DEVICES
-    ]
-    entities = []
-
-    for coordinator in aws_coordinators:
-        for feature_class in feature_class_mapping:
-            if coordinator.blueair_api_device.model.supports_feature(feature_class[0]):
-                entities.append(feature_class[1](coordinator))
-    async_add_entities(entities)
 
 
 class BlueairTemperatureSensor(BlueairEntity, SensorEntity):
@@ -70,6 +35,10 @@ class BlueairTemperatureSensor(BlueairEntity, SensorEntity):
 
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+
+    @classmethod
+    def is_supported(kls, coordinator):
+        return coordinator.temperature is not NotImplemented
 
     def __init__(self, coordinator):
         """Initialize the temperature sensor."""
@@ -95,6 +64,11 @@ class BlueairHumiditySensor(BlueairEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.HUMIDITY
     _attr_native_unit_of_measurement = PERCENTAGE
 
+    @classmethod
+    def is_supported(kls, coordinator):
+        return coordinator.humidity is not NotImplemented
+
+
     def __init__(self, coordinator):
         """Initialize the humidity sensor."""
         super().__init__("Humidity", coordinator)
@@ -119,6 +93,10 @@ class BlueairVOCSensor(BlueairEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS
     _attr_native_unit_of_measurement = CONCENTRATION_PARTS_PER_BILLION
 
+    @classmethod
+    def is_supported(kls, coordinator):
+        return coordinator.voc is not NotImplemented
+
     def __init__(self, coordinator):
         """Initialize the VOC sensor."""
         super().__init__("voc", coordinator)
@@ -142,6 +120,10 @@ class BlueairPM1Sensor(BlueairEntity, SensorEntity):
 
     _attr_device_class = SensorDeviceClass.PM1
     _attr_native_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+
+    @classmethod
+    def is_supported(kls, coordinator):
+        return coordinator.pm1 is not NotImplemented
 
     def __init__(self, coordinator):
         """Initialize the pm1 sensor."""
@@ -170,6 +152,10 @@ class BlueairPM10Sensor(BlueairEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.PM10
     _attr_native_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 
+    @classmethod
+    def is_supported(kls, coordinator):
+        return coordinator.pm10 is not NotImplemented
+
     def __init__(self, coordinator):
         """Initialize the pm10 sensor."""
         super().__init__("pm10", coordinator)
@@ -197,6 +183,10 @@ class BlueairPM25Sensor(BlueairEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.PM25
     _attr_native_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 
+    @classmethod
+    def is_supported(kls, coordinator):
+        return coordinator.pm25 is not NotImplemented
+
     def __init__(self, coordinator):
         """Initialize the pm25 sensor."""
         super().__init__("pm25", coordinator)
@@ -223,6 +213,10 @@ class BlueairCO2Sensor(BlueairEntity, SensorEntity):
 
     _attr_device_class = SensorDeviceClass.CO2
     _attr_native_unit_of_measurement = CONCENTRATION_PARTS_PER_MILLION
+
+    @classmethod
+    def is_supported(kls, coordinator):
+        return coordinator.co2 is not NotImplemented
 
     def __init__(self, coordinator):
         """Initialize the co2 sensor."""

--- a/custom_components/ha_blueair/sensor.py
+++ b/custom_components/ha_blueair/sensor.py
@@ -8,10 +8,8 @@ from homeassistant.const import (
     CONCENTRATION_PARTS_PER_BILLION,
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
 )
-from blueair_api import FeatureEnum, DeviceAws
+from blueair_api import DeviceAws
 
-from .blueair_aws_data_update_coordinator import BlueairAwsDataUpdateCoordinator
-from .blueair_data_update_coordinator import BlueairDataUpdateCoordinator
 from .entity import BlueairEntity, async_setup_entry_helper
 
 

--- a/custom_components/ha_blueair/sensor.py
+++ b/custom_components/ha_blueair/sensor.py
@@ -35,7 +35,7 @@ class BlueairTemperatureSensor(BlueairEntity, SensorEntity):
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
     @classmethod
-    def is_supported(kls, coordinator):
+    def is_implemented(kls, coordinator):
         return coordinator.temperature is not NotImplemented
 
     def __init__(self, coordinator):
@@ -63,7 +63,7 @@ class BlueairHumiditySensor(BlueairEntity, SensorEntity):
     _attr_native_unit_of_measurement = PERCENTAGE
 
     @classmethod
-    def is_supported(kls, coordinator):
+    def is_implemented(kls, coordinator):
         return coordinator.humidity is not NotImplemented
 
 
@@ -92,7 +92,7 @@ class BlueairVOCSensor(BlueairEntity, SensorEntity):
     _attr_native_unit_of_measurement = CONCENTRATION_PARTS_PER_BILLION
 
     @classmethod
-    def is_supported(kls, coordinator):
+    def is_implemented(kls, coordinator):
         return coordinator.voc is not NotImplemented
 
     def __init__(self, coordinator):
@@ -120,7 +120,7 @@ class BlueairPM1Sensor(BlueairEntity, SensorEntity):
     _attr_native_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 
     @classmethod
-    def is_supported(kls, coordinator):
+    def is_implemented(kls, coordinator):
         return coordinator.pm1 is not NotImplemented
 
     def __init__(self, coordinator):
@@ -151,7 +151,7 @@ class BlueairPM10Sensor(BlueairEntity, SensorEntity):
     _attr_native_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 
     @classmethod
-    def is_supported(kls, coordinator):
+    def is_implemented(kls, coordinator):
         return coordinator.pm10 is not NotImplemented
 
     def __init__(self, coordinator):
@@ -182,7 +182,7 @@ class BlueairPM25Sensor(BlueairEntity, SensorEntity):
     _attr_native_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 
     @classmethod
-    def is_supported(kls, coordinator):
+    def is_implemented(kls, coordinator):
         return coordinator.pm25 is not NotImplemented
 
     def __init__(self, coordinator):
@@ -213,7 +213,7 @@ class BlueairCO2Sensor(BlueairEntity, SensorEntity):
     _attr_native_unit_of_measurement = CONCENTRATION_PARTS_PER_MILLION
 
     @classmethod
-    def is_supported(kls, coordinator):
+    def is_implemented(kls, coordinator):
         return coordinator.co2 is not NotImplemented
 
     def __init__(self, coordinator):

--- a/custom_components/ha_blueair/switch.py
+++ b/custom_components/ha_blueair/switch.py
@@ -4,10 +4,7 @@ from homeassistant.components.switch import (
     SwitchEntity,
     SwitchDeviceClass,
 )
-from blueair_api import ModelEnum
 
-from .const import DOMAIN, DATA_AWS_DEVICES
-from .blueair_aws_data_update_coordinator import BlueairAwsDataUpdateCoordinator
 from .entity import BlueairEntity, async_setup_entry_helper
 
 

--- a/custom_components/ha_blueair/switch.py
+++ b/custom_components/ha_blueair/switch.py
@@ -23,7 +23,7 @@ class BlueairChildLockSwitchEntity(BlueairEntity, SwitchEntity):
     _attr_device_class = SwitchDeviceClass.SWITCH
 
     @classmethod
-    def is_supported(kls, coordinator):
+    def is_implemented(kls, coordinator):
         return coordinator.child_lock is not NotImplemented
 
     def __init__(self, coordinator):
@@ -46,7 +46,7 @@ class BlueairAutoFanModeSwitchEntity(BlueairEntity, SwitchEntity):
     _attr_device_class = SwitchDeviceClass.SWITCH
 
     @classmethod
-    def is_supported(kls, coordinator):
+    def is_implemented(kls, coordinator):
         return coordinator.fan_auto_mode is not NotImplemented
 
     def __init__(self, coordinator):
@@ -69,7 +69,7 @@ class BlueairNightModeSwitchEntity(BlueairEntity, SwitchEntity):
     _attr_device_class = SwitchDeviceClass.SWITCH
 
     @classmethod
-    def is_supported(kls, coordinator):
+    def is_implemented(kls, coordinator):
         return coordinator.night_mode is not NotImplemented
 
     def __init__(self, coordinator):
@@ -97,7 +97,7 @@ class BlueairWickDryModeSwitchEntity(BlueairEntity, SwitchEntity):
     _attr_device_class = SwitchDeviceClass.SWITCH
 
     @classmethod
-    def is_supported(kls, coordinator):
+    def is_implemented(kls, coordinator):
         return coordinator.wick_dry_mode is not NotImplemented
 
     def __init__(self, coordinator):

--- a/custom_components/ha_blueair/switch.py
+++ b/custom_components/ha_blueair/switch.py
@@ -11,35 +11,23 @@ from .blueair_aws_data_update_coordinator import BlueairAwsDataUpdateCoordinator
 from .entity import BlueairEntity
 
 
-async def async_setup_entry(hass, _config_entry, async_add_entities):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Blueair sensors from config entry."""
-    aws_coordinators: list[BlueairAwsDataUpdateCoordinator] = hass.data[DOMAIN][
-        DATA_AWS_DEVICES
-    ]
-    entities = []
-    for coordinator in aws_coordinators:
-        if coordinator.model == ModelEnum.HUMIDIFIER_H35I:
-            entities.extend(
-                [
-                    BlueairChildLockSwitchEntity(coordinator),
-                    BlueairAutoFanModeSwitchEntity(coordinator),
-                    BlueairNightModeSwitchEntity(coordinator),
-                    BlueairWickDryModeSwitchEntity(coordinator),
-                ]
-            )
-        else:
-            entities.extend(
-                [
-                    BlueairChildLockSwitchEntity(coordinator),
-                    BlueairAutoFanModeSwitchEntity(coordinator),
-                    BlueairNightModeSwitchEntity(coordinator),
-                ]
-            )
-    async_add_entities(entities)
+    async_setup_entry_helper(hass, config_entry, async_add_entities,
+        entity_classes[
+            BlueairChildLockSwitchEntity,
+            BlueairAutoFanModeSwitchEntity,
+            BlueairNightModeSwitchEntity,
+            BlueairWickDryModeSwitchEntity,
+    ])
 
 
 class BlueairChildLockSwitchEntity(BlueairEntity, SwitchEntity):
     _attr_device_class = SwitchDeviceClass.SWITCH
+
+    @classmethod
+    def is_supported(kls, coordinator):
+        return coordinator.child_lock is not NotImplemented
 
     def __init__(self, coordinator):
         super().__init__("Child Lock", coordinator)
@@ -60,6 +48,10 @@ class BlueairChildLockSwitchEntity(BlueairEntity, SwitchEntity):
 class BlueairAutoFanModeSwitchEntity(BlueairEntity, SwitchEntity):
     _attr_device_class = SwitchDeviceClass.SWITCH
 
+    @classmethod
+    def is_supported(kls, coordinator):
+        return coordinator.fan_auto_mode is not NotImplemented
+
     def __init__(self, coordinator):
         super().__init__("Auto Fan Mode", coordinator)
 
@@ -78,6 +70,10 @@ class BlueairAutoFanModeSwitchEntity(BlueairEntity, SwitchEntity):
 
 class BlueairNightModeSwitchEntity(BlueairEntity, SwitchEntity):
     _attr_device_class = SwitchDeviceClass.SWITCH
+
+    @classmethod
+    def is_supported(kls, coordinator):
+        return coordinator.night_mode is not NotImplemented
 
     def __init__(self, coordinator):
         super().__init__("Night Mode", coordinator)
@@ -102,6 +98,10 @@ class BlueairNightModeSwitchEntity(BlueairEntity, SwitchEntity):
 
 class BlueairWickDryModeSwitchEntity(BlueairEntity, SwitchEntity):
     _attr_device_class = SwitchDeviceClass.SWITCH
+
+    @classmethod
+    def is_supported(kls, coordinator):
+        return coordinator.wick_dry_mode is not NotImplemented
 
     def __init__(self, coordinator):
         super().__init__("Wick Dry Mode", coordinator)

--- a/custom_components/ha_blueair/switch.py
+++ b/custom_components/ha_blueair/switch.py
@@ -8,13 +8,13 @@ from blueair_api import ModelEnum
 
 from .const import DOMAIN, DATA_AWS_DEVICES
 from .blueair_aws_data_update_coordinator import BlueairAwsDataUpdateCoordinator
-from .entity import BlueairEntity
+from .entity import BlueairEntity, async_setup_entry_helper
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Blueair sensors from config entry."""
     async_setup_entry_helper(hass, config_entry, async_add_entities,
-        entity_classes[
+        entity_classes=[
             BlueairChildLockSwitchEntity,
             BlueairAutoFanModeSwitchEntity,
             BlueairNightModeSwitchEntity,


### PR DESCRIPTION
Marked as fix, as this fixes a regression for H35i where the water shortage and wick dry mode entities were lost since some versions ago.

https://github.com/dahlb/blueair_api/issues/30

This works for my H35i, and HA was able to import all of the module files without errors. Thus most likely will work automatically for most of the AWS backed devices. My sense is that the non-AWS path should need some additional testing and most likely fixes after this change and before the next release.

The following debt were discovered / introduced:

- I run into fiction between the non-aws and the aws code paths, but I think in the end I managed to consolidate them both into the new NotImplemented syntax. In the middle of doing so, I realized that AWS and non AWS update coordinator should have the same interface. This constraint was not enforced by runtime or static checks. Maybe we should consolidate into a single updater, which uses a common blueair_api.Device object to access the API (less code); or introduce a typing.Protocol with runtime check to ensure all methods are implemented (a lot more code).

- another difficulty was the type annotations. I mostly left them as is because we are not running type checker anyway.
  - Attributes should have been marked AttributeType[...]. (They should have at least been `int | None` even before this change). But that would be pulling in a type from blueair_api into the coordinator, which seems to be a layer violation. If we are doing layer violation anyway, then directly accessing the device attributes can actually save us from a lot of redundant definitions between ha_blueair and blueair_api.
  - It should have been `BlueairAwsUpdateCoordinator | BlueairUpdatecoordinator` in several places.
 
