### PR TITLE
A few experiements for anitiflicker.

### DIFF
--- a/custom_components/ha_blueair/const.py
+++ b/custom_components/ha_blueair/const.py
@@ -15,3 +15,6 @@ REGIONS = [REGION_USA, REGION_EU]
 
 DEFAULT_FAN_SPEED_PERCENTAGE = 50
 FILTER_EXPIRED_THRESHOLD = 95
+
+# Wait time to account for latency in Blueair server side state update.
+DEVICE_REFRESH_WAIT_SECONDS = 5

--- a/custom_components/ha_blueair/entity.py
+++ b/custom_components/ha_blueair/entity.py
@@ -45,6 +45,8 @@ class BlueairEntity(CoordinatorEntity):
         self._attr_unique_id = f"{coordinator.id}_{entity_type}"
 
         self.coordinator: BlueairUpdateCoordinator = coordinator
+        self.coordinator.blueair_api_device.register_callback(
+            self.schedule_update_ha_state)
 
     @property
     def device_info(self) -> DeviceInfo:


### PR DESCRIPTION
https://github.com/dahlb/ha_blueair/issues/164

Seems like only the change enabling the callbacks -> ha state update fixed the flickering of entity states on the UI.

However we are amplifying writes to the HA db with the callback triggering state updates for all of the entites using the coordinator/device. We will most likely be required to fix this if we are to be included in ha core (people seem to care about minimizing the size of the db).