### PR TITLE
fix: Reenable always-update

### DIFF
--- a/custom_components/ha_blueair/blueair_update_coordinator.py
+++ b/custom_components/ha_blueair/blueair_update_coordinator.py
@@ -1,6 +1,8 @@
 """Blueair device object."""
 from __future__ import annotations
 import logging
+
+import copy
 from datetime import timedelta
 from abc import ABC, abstractmethod
 
@@ -32,7 +34,8 @@ class BlueairUpdateCoordinator(ABC, DataUpdateCoordinator):
 
         async def refresh() -> BlueAirApiDevice | BlueAirAwsDevice:
             await self.blueair_api_device.refresh()
-            return self.blueair_api_device
+            # returns a copy for always_update detection.
+            return copy.copy(self.blueair_api_device)
 
         super().__init__(
             hass,
@@ -41,7 +44,7 @@ class BlueairUpdateCoordinator(ABC, DataUpdateCoordinator):
             update_interval=timedelta(minutes=5),
             update_method=refresh,
             request_refresh_debouncer=request_refresh_debouncer,
-            always_update=True
+            always_update=False,
         )
 
     @property


### PR DESCRIPTION
I don't like this fix.

Using the copy module usually indicates architecture smell -- e.g. combining APIs of different mutability models like we are doing here.

some cleaner solutions:

1) refactor blueair_api to follow HA's preferred model, splitting the
   API object and the state object to make both semi-'immutable'. The
   end result will likely be effectively breaking up the Device/DeviceAws class
   (which means the API becomes more 'meta'), but there may be a narrow
   path preserving the hard-codedness of the API by effectively
   reimplementing the UpdateCoordinator contract in the DeviceAws
   objects.

2) create a new device object per refresh call. Seems to be awkward.

3) update home assistant to support in-place mutation of the data
   object -- I took a stab at it but I did not like this neither. Because
   it would most likely mean either doing a copy there or store a
   signature/digest of the data object (which implies adding a new
   contract such as requiring the implementation of `__hash__`)