### PR TITLE
français

### DIFF
--- a/custom_components/ha_blueair/translations/fr.json
+++ b/custom_components/ha_blueair/translations/fr.json
@@ -1,0 +1,35 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Authentification BlueAir",
+        "description": "Connectez-vous",
+        "data": {
+          "region": "Région",
+          "username": "Identifiant",
+          "password": "Mot de passe"
+        }
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "L'intégration BlueAir nécessite la ré-authentification de votre compte."
+      }
+    },
+    "error": {
+      "auth": "Échec de connexion. Veuillez utiliser l'application officielle pour vous déconnecter, puis reconnectez-vous et réessayez."
+    }
+  },
+  "entity": {
+    "humidifier": {
+      "ha_blueair": {
+        "state_attributes": {
+          "mode": {
+            "state": {
+              "fan_speed": "Vitesse du ventilateur"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Provides translation for new humidifer custom mode and config flow. Requires #170, might break otherwise.

This does not translate all the entities, it looks like this would require translation keys to be added everywhere so I'm assuming the other languages aren't fully localized yet either