### PR TITLE
Mark all entities as unavailable when coordinator is disconnected

### DIFF
--- a/custom_components/ha_blueair/binary_sensor.py
+++ b/custom_components/ha_blueair/binary_sensor.py
@@ -56,6 +56,11 @@ class BlueairOnlineSensor(BlueairBinarySensor):
         else:
             return "mdi:wifi-strength-outline"
 
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return True
+
 
 class BlueairWaterShortageSensor(BlueairBinarySensor):
     entity_description = BinarySensorEntityDescription(

--- a/custom_components/ha_blueair/entity.py
+++ b/custom_components/ha_blueair/entity.py
@@ -53,6 +53,11 @@ class BlueairEntity(CoordinatorEntity[BlueairUpdateCoordinator]):
             name=self.coordinator.device_name,
         )
 
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success and self.coordinator.online
+
     async def async_update(self):
         """Update Blueair entity."""
         await super().async_update()

--- a/custom_components/ha_blueair/humidifier.py
+++ b/custom_components/ha_blueair/humidifier.py
@@ -52,11 +52,6 @@ class BlueairAwsHumidifier(BlueairEntity, HumidifierEntity):
         super().__init__("Humidifier", coordinator)
 
     @property
-    def available(self) -> bool:
-        """Return if entity is available."""
-        return self.coordinator.last_update_success and self.coordinator.online
-
-    @property
     def mode(self):
         if self.coordinator.night_mode:
             return MODE_SLEEP


### PR DESCRIPTION
This PR updates the base entity class to use the available method that had been implemented on the humidifier class. This ensures that all of the entities generated show unavailable when the device is disconnected. The connectivity sensor overrides this to ensure that connectivity status is always shown correctly.