### PR TITLE
Implement night and auto modes as fan presets

### DIFF
--- a/custom_components/ha_blueair/const.py
+++ b/custom_components/ha_blueair/const.py
@@ -37,3 +37,5 @@ FILTER_EXPIRED_THRESHOLD = 95
 
 # Custom Mode Constants
 MODE_FAN_SPEED = "fan_speed"
+MODE_AUTO = "auto"
+MODE_NIGHT = "night"

--- a/custom_components/ha_blueair/entity.py
+++ b/custom_components/ha_blueair/entity.py
@@ -25,6 +25,7 @@ def async_setup_entry_helper(hass, config_entry, async_add_entities, entity_clas
 
 class BlueairEntity(CoordinatorEntity[BlueairUpdateCoordinator]):
     """A base class for Blueair entities."""
+    _attr_translation_key = DOMAIN
 
     @classmethod
     def is_implemented(kls, coordinator) -> bool:

--- a/custom_components/ha_blueair/fan.py
+++ b/custom_components/ha_blueair/fan.py
@@ -21,6 +21,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             BlueairAwsFan,
     ])
 
+
 class BlueairFan(BlueairEntity, FanEntity):
     """Controls Fan."""
 

--- a/custom_components/ha_blueair/fan.py
+++ b/custom_components/ha_blueair/fan.py
@@ -7,20 +7,19 @@ from homeassistant.components.fan import (
 )
 
 from .blueair_update_coordinator import BlueairUpdateCoordinator
-from .const import DEFAULT_FAN_SPEED_PERCENTAGE
+from .const import DEFAULT_FAN_SPEED_PERCENTAGE, MODE_AUTO, MODE_NIGHT
 from .blueair_update_coordinator_device import BlueairUpdateCoordinatorDevice
 from .blueair_update_coordinator_device_aws import BlueairUpdateCoordinatorDeviceAws
 from .entity import BlueairEntity, async_setup_entry_helper
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up the Blueair sensors from config entry."""
+    """Set up the Blueair fans from config entry."""
     async_setup_entry_helper(hass, config_entry, async_add_entities,
         entity_classes=[
             BlueairFan,
             BlueairAwsFan,
     ])
-
 
 class BlueairFan(BlueairEntity, FanEntity):
     """Controls Fan."""
@@ -30,12 +29,19 @@ class BlueairFan(BlueairEntity, FanEntity):
         return isinstance(coordinator, BlueairUpdateCoordinatorDevice)
 
     def __init__(self, coordinator: BlueairUpdateCoordinator):
-        """Initialize the temperature sensor."""
-        super().__init__("Fan", coordinator)
+        """Initialize the fan entity."""
+        self._attr_translation_key = "ha_blueair"
+        self._attr_preset_modes = []
+        if coordinator.fan_auto_mode is not NotImplemented:
+            self._attr_preset_modes.append(MODE_AUTO)
+        if coordinator.night_mode is not NotImplemented:
+            self._attr_preset_modes.append(MODE_NIGHT)
 
-    @property
-    def supported_features(self) -> int:
-        return FanEntityFeature.SET_SPEED | FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+        self._attr_supported_features = FanEntityFeature.SET_SPEED | FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+        if self._attr_preset_modes:
+            self._attr_supported_features |= FanEntityFeature.PRESET_MODE
+
+        super().__init__("Fan", coordinator)
 
     @property
     def is_on(self) -> int:
@@ -57,8 +63,19 @@ class BlueairFan(BlueairEntity, FanEntity):
         else:
             new_speed = "0"
 
+        if self.coordinator.fan_auto_mode is True:
+            await self.coordinator.set_fan_auto_mode(False)
+        if self.coordinator.night_mode is True:
+            await self.coordinator.set_night_mode(False)
         await self.coordinator.set_fan_speed(new_speed)
         self.async_write_ha_state()
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set the preset mode of the fan."""
+        if preset_mode == MODE_AUTO:
+            await self.coordinator.set_fan_auto_mode(True)
+        elif preset_mode == MODE_NIGHT:
+            await self.coordinator.set_night_mode(True)
 
     async def async_turn_off(self, **kwargs: any) -> None:
         await self.coordinator.set_fan_speed("0")
@@ -73,6 +90,8 @@ class BlueairFan(BlueairEntity, FanEntity):
         await self.coordinator.set_fan_speed("1")
         if percentage is not None:
             await self.async_set_percentage(percentage=percentage)
+        elif preset_mode is not None:
+            await self.async_set_preset_mode(preset_mode)
         else:
             self.async_write_ha_state()
 
@@ -80,6 +99,15 @@ class BlueairFan(BlueairEntity, FanEntity):
     def speed_count(self) -> int:
         """Return the number of speeds the fan supports."""
         return self.coordinator.speed_count
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the current preset mode, e.g., auto, smart, interval, favorite."""
+        if self.coordinator.fan_auto_mode is True:
+            return MODE_AUTO
+        if self.coordinator.night_mode is True:
+            return MODE_NIGHT
+        return None
 
 
 class BlueairAwsFan(BlueairEntity, FanEntity):
@@ -90,15 +118,20 @@ class BlueairAwsFan(BlueairEntity, FanEntity):
         return isinstance(coordinator, BlueairUpdateCoordinatorDeviceAws)
 
     def __init__(self, coordinator: BlueairUpdateCoordinatorDeviceAws):
-        """Initialize the temperature sensor."""
-        super().__init__("Fan", coordinator)
+        """Initialize the fan entity."""
+        self._attr_preset_modes = []
+        if coordinator.fan_auto_mode is not NotImplemented:
+            self._attr_preset_modes.append(MODE_AUTO)
+        if coordinator.night_mode is not NotImplemented:
+            self._attr_preset_modes.append(MODE_NIGHT)
 
-    @property
-    def supported_features(self) -> int:
-        features = FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
-        if self.coordinator.fan_speed is not NotImplemented:
-            features |= FanEntityFeature.SET_SPEED
-        return features
+        self._attr_supported_features = FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+        if coordinator.fan_speed is not NotImplemented:
+            self._attr_supported_features |= FanEntityFeature.SET_SPEED
+        if self._attr_preset_modes:
+            self._attr_supported_features |= FanEntityFeature.PRESET_MODE
+
+        super().__init__("Fan", coordinator)
 
     @property
     def is_on(self) -> int:
@@ -110,8 +143,19 @@ class BlueairAwsFan(BlueairEntity, FanEntity):
         return int((self.coordinator.fan_speed * 100) // self.coordinator.speed_count)
 
     async def async_set_percentage(self, percentage: int) -> None:
+        if self.coordinator.fan_auto_mode is True:
+            await self.coordinator.set_fan_auto_mode(False)
+        if self.coordinator.night_mode is True:
+            await self.coordinator.set_night_mode(False)
         await self.coordinator.set_fan_speed(int(round(percentage / 100 * self.coordinator.speed_count)))
         self.async_write_ha_state()
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set the preset mode of the fan."""
+        if preset_mode == MODE_AUTO:
+            await self.coordinator.set_fan_auto_mode(True)
+        elif preset_mode == MODE_NIGHT:
+            await self.coordinator.set_night_mode(True)
 
     async def async_turn_off(self, **kwargs: any) -> None:
         await self.coordinator.set_running(False)
@@ -133,6 +177,8 @@ class BlueairAwsFan(BlueairEntity, FanEntity):
             percentage = DEFAULT_FAN_SPEED_PERCENTAGE
         if percentage is not None:
             await self.async_set_percentage(percentage=percentage)
+        elif preset_mode is not None:
+            await self.async_set_preset_mode(preset_mode)
         else:
             self.async_write_ha_state()
 
@@ -140,3 +186,12 @@ class BlueairAwsFan(BlueairEntity, FanEntity):
     def speed_count(self) -> int:
         """Return the number of speeds the fan supports."""
         return self.coordinator.speed_count
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the current preset mode, e.g., auto, smart, interval, favorite."""
+        if self.coordinator.fan_auto_mode is True:
+            return MODE_AUTO
+        if self.coordinator.night_mode is True:
+            return MODE_NIGHT
+        return None

--- a/custom_components/ha_blueair/fan.py
+++ b/custom_components/ha_blueair/fan.py
@@ -31,7 +31,6 @@ class BlueairFan(BlueairEntity, FanEntity):
 
     def __init__(self, coordinator: BlueairUpdateCoordinator):
         """Initialize the fan entity."""
-        self._attr_translation_key = "ha_blueair"
         self._attr_preset_modes = []
         if coordinator.fan_auto_mode is not NotImplemented:
             self._attr_preset_modes.append(MODE_AUTO)

--- a/custom_components/ha_blueair/fan.py
+++ b/custom_components/ha_blueair/fan.py
@@ -50,7 +50,10 @@ class BlueairFan(BlueairEntity, FanEntity):
     @property
     def percentage(self) -> int:
         """Return the current speed percentage."""
-        return int(round(self.coordinator.fan_speed * 33.33, 0))
+        if self.preset_mode is None:
+          return int(round(self.coordinator.fan_speed * 33.33, 0))
+        else:
+          return None
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Sets fan speed percentage."""
@@ -140,7 +143,10 @@ class BlueairAwsFan(BlueairEntity, FanEntity):
     @property
     def percentage(self) -> int:
         """Return the current speed percentage."""
-        return int((self.coordinator.fan_speed * 100) // self.coordinator.speed_count)
+        if self.preset_mode is None:
+          return int((self.coordinator.fan_speed * 100) // self.coordinator.speed_count)
+        else:
+          return None
 
     async def async_set_percentage(self, percentage: int) -> None:
         if self.coordinator.fan_auto_mode is True:

--- a/custom_components/ha_blueair/humidifier.py
+++ b/custom_components/ha_blueair/humidifier.py
@@ -43,7 +43,6 @@ class BlueairAwsHumidifier(BlueairEntity, HumidifierEntity):
         """Initialize the humidifer."""
         self._attr_device_class = HumidifierDeviceClass.HUMIDIFIER
         self._attr_supported_features = HumidifierEntityFeature.MODES
-        self._attr_translation_key = "ha_blueair"
         self._attr_available_modes = [
             MODE_AUTO,
             MODE_SLEEP,

--- a/custom_components/ha_blueair/icons.json
+++ b/custom_components/ha_blueair/icons.json
@@ -1,0 +1,16 @@
+{
+  "entity": {
+    "fan": {
+      "ha_blueair": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "mdi:fan-auto",
+              "night": "mdi:weather-night"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/custom_components/ha_blueair/strings.json
+++ b/custom_components/ha_blueair/strings.json
@@ -30,6 +30,18 @@
           }
         }
       }
+    },
+    "fan": {
+      "ha_blueair": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Auto",
+              "night": "Night"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/custom_components/ha_blueair/switch.py
+++ b/custom_components/ha_blueair/switch.py
@@ -17,8 +17,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         entity_classes=[
             BlueairChildLockSwitchEntity,
             BlueairGermShieldSwitchEntity,
-            BlueairAutoFanModeSwitchEntity,
-            BlueairNightModeSwitchEntity,
             BlueairWickDryModeSwitchEntity,
     ])
 
@@ -56,22 +54,6 @@ class BlueairGermShieldSwitchEntity(BlueairSwitchEntity):
     entity_description = SwitchEntityDescription(
         key="germ_shield",
         name="Germ Shield",
-        device_class=SwitchDeviceClass.SWITCH,
-    )
-
-
-class BlueairAutoFanModeSwitchEntity(BlueairSwitchEntity):
-    entity_description = SwitchEntityDescription(
-        key="fan_auto_mode",
-        name="Auto Fan Mode",
-        device_class=SwitchDeviceClass.SWITCH,
-    )
-
-
-class BlueairNightModeSwitchEntity(BlueairSwitchEntity):
-    entity_description = SwitchEntityDescription(
-        key="night_mode",
-        name="Night Mode",
         device_class=SwitchDeviceClass.SWITCH,
     )
 

--- a/custom_components/ha_blueair/translations/en.json
+++ b/custom_components/ha_blueair/translations/en.json
@@ -30,6 +30,18 @@
           }
         }
       }
+    },
+    "fan": {
+      "ha_blueair": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Auto",
+              "night": "Night"
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
This PR replaces the auto and night switches to be fan preset modes, since these modes take exclusive control of the fan speed.

I didn't update the wick dry mode, since from the docs I can see it looks like this feature is toggled independently of fan speed, and just takes over for periods during the day. I don't have a humidifier though.

See https://developers.home-assistant.io/docs/core/entity/fan#preset-modes

<img width="441" alt="image" src="https://github.com/user-attachments/assets/708515d4-c684-473e-b63a-0962b68e2b82" />

<img width="296" alt="image" src="https://github.com/user-attachments/assets/2b5c9032-33a8-4fef-aa5d-021220da0af2" />

