### PR TITLE
Child lock icons

### DIFF
--- a/custom_components/ha_blueair/icons.json
+++ b/custom_components/ha_blueair/icons.json
@@ -11,6 +11,14 @@
           }
         }
       }
+    },
+    "switch": {
+      "child_lock": {
+        "default": "mdi:lock",
+        "state": {
+          "off": "mdi:lock-open-variant"
+        }
+      }
     }
   }
 }

--- a/custom_components/ha_blueair/switch.py
+++ b/custom_components/ha_blueair/switch.py
@@ -48,6 +48,7 @@ class BlueairChildLockSwitchEntity(BlueairSwitchEntity):
         name="Child Lock",
         device_class=SwitchDeviceClass.SWITCH,
     )
+    _attr_translation_key = "child_lock"
 
 
 class BlueairGermShieldSwitchEntity(BlueairSwitchEntity):


### PR DESCRIPTION
Adds lock and unlocked icons for the child lock switch.

<img width="257" alt="image" src="https://github.com/user-attachments/assets/abaf236a-9d18-4c4b-a015-2aeb145d488c" />
<img width="256" alt="image" src="https://github.com/user-attachments/assets/bcec4f84-8565-4319-8497-91a8c2fcd884" />
