### PR TITLE
feat: links with api PR#77 sku model 110178 has a max speed percent of 91

### DIFF
--- a/custom_components/ha_blueair/blueair_update_coordinator_device_aws.py
+++ b/custom_components/ha_blueair/blueair_update_coordinator_device_aws.py
@@ -42,6 +42,7 @@ class BlueairUpdateCoordinatorDeviceAws(BlueairUpdateCoordinator):
             ModelEnum.MAX_211I,
             ModelEnum.MAX_311I,
             ModelEnum.MAX_311I_PLUS,
+            ModelEnum.MAX_3250I,
             ModelEnum.PROTECT_7440I,
             ModelEnum.PROTECT_7470I
         ]:


### PR DESCRIPTION
max fan speed for the Blueair Pure Max 3250i is 91