### PR TITLE
feat: links with api PR#80 sku model 110178 has a max speed percent of 91

### DIFF
--- a/custom_components/ha_blueair/blueair_update_coordinator_device_aws.py
+++ b/custom_components/ha_blueair/blueair_update_coordinator_device_aws.py
@@ -43,6 +43,7 @@ class BlueairUpdateCoordinatorDeviceAws(BlueairUpdateCoordinator):
             ModelEnum.MAX_311I,
             ModelEnum.MAX_311I_PLUS,
             ModelEnum.MAX_3250I,
+            ModelEnum.MAX_3650I,
             ModelEnum.PROTECT_7440I,
             ModelEnum.PROTECT_7470I
         ]:


### PR DESCRIPTION
set max speed for Blueair Pure Max 3650I to 91