### PR TITLE
# feat: use blueair_api model_name and mood_brightness_max

### DIFF
--- a/custom_components/ha_blueair/blueair_update_coordinator_device_aws.py
+++ b/custom_components/ha_blueair/blueair_update_coordinator_device_aws.py
@@ -9,7 +9,7 @@ from homeassistant.util.color import (
     brightness_to_value,
 )
 
-from blueair_api import ModelEnum, DeviceAws
+from blueair_api import DeviceAws
 
 from .blueair_update_coordinator import BlueairUpdateCoordinator
 
@@ -22,11 +22,8 @@ class BlueairUpdateCoordinatorDeviceAws(BlueairUpdateCoordinator):
 
     @property
     def model(self) -> str:
-        """Return api package enum of device model."""
-        model = self.blueair_api_device.model
-        if model == ModelEnum.UNKNOWN:
-            model = f"Unknown ({self.blueair_api_device.sku})"
-        return model
+        """Return human-readable product name for device registry."""
+        return self.blueair_api_device.model_name
 
     @property
     def hw_version(self) -> str:
@@ -168,9 +165,7 @@ class BlueairUpdateCoordinatorDeviceAws(BlueairUpdateCoordinator):
 
     @property
     def mood_brightness_scale(self) -> tuple[int, int]:
-        if self.blueair_api_device.model == ModelEnum.HUMIDIFIER_H76I:
-            return (1, 3)
-        return (1, 100)
+        return (1, self.blueair_api_device.mood_brightness_max)
 
     @property
     def mood_brightness(self) -> int | None | NotImplemented:

--- a/custom_components/ha_blueair/manifest.json
+++ b/custom_components/ha_blueair/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dahlb/ha_blueair/issues",
   "loggers": ["ha_blueair", "blueair_api"],
-  "requirements": ["blueair-api==1.49.1"],
+  "requirements": ["blueair-api==1.50.0"],
   "version": "1.46.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ colorlog==6.10.1
 homeassistant==2025.6.0
 pip>=25.3
 ruff==0.15.9
-blueair-api==1.49.1
+blueair-api==1.50.0


### PR DESCRIPTION
## Problem

The device model shown in the HA device registry comes from `ModelEnum`, which only covers ~20 SKUs. Unrecognized devices show as `"Unknown (sku)"`. The mood brightness scale for the H76i was determined by comparing against a `ModelEnum` value, coupling the coordinator to the enum.

Fixes #329 

## Solution

Use the new data-driven properties from blueair_api:

- **`model_name`** — resolves 418 SKUs to human-readable product names (e.g. SKU `111582` → "Blueair Blue Pure 511i Max")
- **`mood_brightness_max`** — the device reports its own mood light range, removing the need for model-specific checks here

## Changes

| File | Change |
|------|--------|
| `blueair_update_coordinator_device_aws.py` | `model` property delegates to `device.model_name`; `mood_brightness_scale` uses `device.mood_brightness_max`; removed `ModelEnum` import |

## Before / After

```python
# Before
from blueair_api import ModelEnum, DeviceAws

def model(self) -> str:
    model = self.blueair_api_device.model
    if model == ModelEnum.UNKNOWN:
        model = f"Unknown ({self.blueair_api_device.sku})"
    return model

def mood_brightness_scale(self) -> tuple[int, int]:
    if self.blueair_api_device.model == ModelEnum.HUMIDIFIER_H76I:
        return (1, 3)
    return (1, 100)
```

```python
# After
from blueair_api import DeviceAws

def model(self) -> str:
    return self.blueair_api_device.model_name

def mood_brightness_scale(self) -> tuple[int, int]:
    return (1, self.blueair_api_device.mood_brightness_max)
```