### PR TITLE
fix: wire MQTT credential refresher for automatic reconnect

### DIFF
--- a/custom_components/ha_blueair/__init__.py
+++ b/custom_components/ha_blueair/__init__.py
@@ -176,12 +176,23 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
                 mqtt_client.on_sensor_data = on_sensor_data
                 mqtt_client.on_event = on_event
 
+                # Credential refresher for automatic reconnect on token expiry.
+                async def refresh_mqtt_credentials():
+                    await aws_http_client.refresh_access_token()
+                    return (
+                        aws_http_client.mqtt_auth_name,
+                        aws_http_client.mqtt_auth_signature,
+                        aws_http_client.mqtt_auth_token,
+                    )
+
+                mqtt_client.credential_refresher = refresh_mqtt_credentials
+
                 for device in aws_devices:
                     mqtt_client.register_device(device.uuid)
 
                 # Run connect in executor to avoid blocking the event loop
                 # (TLS handshake is a blocking operation)
-                await hass.async_add_executor_job(mqtt_client.connect)
+                await hass.async_add_executor_job(mqtt_client.connect, hass.loop)
                 _LOGGER.info("MQTT real-time updates started for %d device(s)", len(aws_devices))
             except Exception:
                 _LOGGER.exception("Failed to start MQTT, falling back to polling only")

--- a/custom_components/ha_blueair/manifest.json
+++ b/custom_components/ha_blueair/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dahlb/ha_blueair/issues",
   "loggers": ["ha_blueair", "blueair_api"],
-  "requirements": ["blueair-api==1.50.0"],
+  "requirements": ["blueair-api==1.50.1"],
   "version": "1.47.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ colorlog==6.10.1
 homeassistant==2025.6.0
 pip>=25.3
 ruff==0.15.9
-blueair-api==1.50.0
+blueair-api==1.50.1


### PR DESCRIPTION
Fixes #328

## Problem

When the MQTT connection to the Blueair cloud drops (token expiry after 24h, network issues, or server-side disconnects), sensors get stuck at their last value (or 0) and never recover until HA is restarted. The MQTT client had no way to obtain fresh authentication tokens for reconnection.

Users reported:
- Sensors not updating ("like every 10 minutes or so")
- `MQTT disconnected unexpectedly: reason_code=Unspecified error` repeated in logs
- Values crash to 0 and stay stuck for ~1 hour
- Forcing a reload of the integration temporarily fixes it

## Solution

Wire the new `credential_refresher` callback from blueair_api's MQTT client so it can automatically refresh tokens and reconnect on disconnect.

## Changes

| File | Change |
|------|--------|
| `__init__.py` | Added `refresh_mqtt_credentials()` async function that calls `aws_http_client.refresh_access_token()` and returns fresh MQTT tokens; set as `mqtt_client.credential_refresher`; pass `hass.loop` to `mqtt_client.connect()` |

## How It Works

```python
async def refresh_mqtt_credentials():
    await aws_http_client.refresh_access_token()
    return (
        aws_http_client.mqtt_auth_name,
        aws_http_client.mqtt_auth_signature,
        aws_http_client.mqtt_auth_token,
    )

mqtt_client.credential_refresher = refresh_mqtt_credentials
await hass.async_add_executor_job(mqtt_client.connect, hass.loop)
```

On unexpected disconnect, the MQTT client:
1. Paho may auto-reconnect instantly with existing credentials (handles transient blips)
2. The reconnect loop sleeps, then stops the old client and calls `refresh_mqtt_credentials()` via the HA event loop
3. Builds a new client with fresh WSS headers
4. Reconnects (exponential backoff: 5s → 300s max if repeated failures)

REST polling continues unchanged as fallback throughout.