### PR TITLE
fix: bump blueair-api to 1.50.2 (MQTT token expiry fix)

### DIFF
--- a/custom_components/ha_blueair/manifest.json
+++ b/custom_components/ha_blueair/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dahlb/ha_blueair/issues",
   "loggers": ["ha_blueair", "blueair_api"],
-  "requirements": ["blueair-api==1.50.1"],
+  "requirements": ["blueair-api==1.50.2"],
   "version": "1.47.1"
 }


### PR DESCRIPTION
blueair-api 1.50.2 fixes the stale JWT loop that caused MQTT credential refresh to fail with 401 Id Token Expired on every reconnect attempt.