### PR TITLE
fix: bump blueair-api to 1.50.4 (MQTT reconnect and data gap fixes)

### DIFF
--- a/custom_components/ha_blueair/manifest.json
+++ b/custom_components/ha_blueair/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dahlb/ha_blueair/issues",
   "loggers": ["ha_blueair", "blueair_api"],
-  "requirements": ["blueair-api==1.50.2"],
+  "requirements": ["blueair-api==1.50.4"],
   "version": "1.47.2"
 }


### PR DESCRIPTION

Bumps `blueair-api` from 1.50.2 to 1.50.4.

## What's included

### blueair-api 1.50.3 — MQTT reconnect rewrite ([dahlb/blueair_api#128](https://github.com/dahlb/blueair_api/pull/128))

Replaces the custom MQTT reconnect thread with paho's built-in reconnect loop, fixing three issues:

1. **Silent connection death** — the custom reconnect thread relied on `on_disconnect` to spawn it, but with `_reconnect_on_failure = False`, paho's `loop_forever()` daemon thread exits silently on connection loss. MQTT dies with no log and no recovery.

2. **Expired JWT blocks reconnection permanently** — the cached JWT (~5 min lifetime) was never cleared on failure. Every reconnect retry sent the stale token, got `401 Id Token Expired`, and backed off to 300s — stuck forever.

3. **TTL keepalive causing data gaps** — the periodic `unsubscribe()` + `subscribe()` cycle (every 15 min) was killing the device's data push. Analysis of a user's 24-hour log showed 12/12 data gaps correlated 100% with keepalive fire times. Fixed by removing the `unsubscribe` — per MQTT 3.1.1 §3.8.4, subscribing to an already-subscribed topic is idempotent.

**Tested**: 47 hours continuous on Home Assistant — 46/46 reconnects successful, 2,802 minutes of data, zero gaps, 24h token boundary crossed twice with no issues.

### blueair-api 1.50.4 — SensorPack crash fix ([dahlb/blueair_api#129](https://github.com/dahlb/blueair_api/pull/129))

Fixes a crash when the device returns non-scalar values in the `vj` field of the SensorPack intermediate representation.

## Related

- Fixes dahlb/ha_blueair#328
