### PR TITLE
feat: use dynamic sensor/state mapping for instant MQTT updates (Phase 2 of #334)

### DIFF
--- a/custom_components/ha_blueair/__init__.py
+++ b/custom_components/ha_blueair/__init__.py
@@ -17,7 +17,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from blueair_api import get_devices, get_aws_devices, LoginError, MqttAwsBlueair
 
-from .mqtt_mapping import map_and_publish_event, map_and_publish_sensor_data
+from .mqtt_mapping import map_and_publish_event
 from .blueair_update_coordinator_device import BlueairUpdateCoordinatorDevice
 from .blueair_update_coordinator_device_aws import BlueairUpdateCoordinatorDeviceAws
 from .const import (
@@ -142,8 +142,30 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
                         _LOGGER.debug(f"sensor data update provided for unknown device: {device_id}")
                         return
                     device = coordinator.blueair_api_device
-                    map_and_publish_sensor_data(sensors, device)
+                    try:
+                        device.apply_sensor_data(sensors)
+                    except Exception:
+                        _LOGGER.exception(
+                            "apply_sensor_data raised for device %s with payload %r",
+                            device_id, sensors,
+                        )
+                        return
+                    device.publish_updates()
                     # Schedule HA state update on the event loop (thread-safe)
+                    hass.loop.call_soon_threadsafe(
+                        coordinator.async_set_updated_data, str(device)
+                    )
+
+                def on_state_change(device_id, state):
+                    """Handle MQTT shadow state change (called from MQTT thread)."""
+                    _LOGGER.debug(f"processing state change {state} for {device_id}")
+                    coordinator = aws_coordinator_map.get(device_id)
+                    if coordinator is None:
+                        _LOGGER.debug(f"state change provided for unknown device: {device_id}")
+                        return
+                    device = coordinator.blueair_api_device
+                    device.apply_state_change(state)
+                    device.publish_updates()
                     hass.loop.call_soon_threadsafe(
                         coordinator.async_set_updated_data, str(device)
                     )
@@ -163,6 +185,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
 
                 mqtt_client.on_sensor_data = on_sensor_data
+                mqtt_client.on_state_change = on_state_change
                 mqtt_client.on_event = on_event
 
                 # Credential refresher for automatic reconnect on token expiry.

--- a/custom_components/ha_blueair/__init__.py
+++ b/custom_components/ha_blueair/__init__.py
@@ -164,7 +164,14 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
                         _LOGGER.debug(f"state change provided for unknown device: {device_id}")
                         return
                     device = coordinator.blueair_api_device
-                    device.apply_state_change(state)
+                    try:
+                        device.apply_state_change(state)
+                    except Exception:
+                        _LOGGER.exception(
+                            "apply_state_change raised for device %s with payload %r",
+                            device_id, state,
+                        )
+                        return
                     device.publish_updates()
                     hass.loop.call_soon_threadsafe(
                         coordinator.async_set_updated_data, str(device)

--- a/custom_components/ha_blueair/blueair_update_coordinator_device_aws.py
+++ b/custom_components/ha_blueair/blueair_update_coordinator_device_aws.py
@@ -225,6 +225,26 @@ class BlueairUpdateCoordinatorDeviceAws(BlueairUpdateCoordinator):
         except (TypeError, ValueError):
             return raw
 
+    @property
+    def rssi(self) -> int | None | NotImplemented:
+        return self.blueair_api_device.rssi
+
+    @property
+    def night_light_brightness(self) -> int | None | NotImplemented:
+        return self.blueair_api_device.night_light_brightness
+
+    @property
+    def timer_state(self) -> int | None | NotImplemented:
+        return self.blueair_api_device.timer_state
+
+    @property
+    def timer_duration(self) -> int | None | NotImplemented:
+        return self.blueair_api_device.timer_duration
+
+    @property
+    def hour_format(self) -> bool | None | NotImplemented:
+        return self.blueair_api_device.hour_format
+
     async def set_running(self, running) -> None:
         await self.blueair_api_device.set_standby(not running)
         await self.async_request_refresh()
@@ -302,4 +322,16 @@ class BlueairUpdateCoordinatorDeviceAws(BlueairUpdateCoordinator):
 
     async def set_fan_speed_0(self, value: int) -> None:
         await self.blueair_api_device.set_fan_speed_0(value)
+        await self.async_request_refresh()
+
+    async def set_night_light_brightness(self, value: int) -> None:
+        await self.blueair_api_device.set_night_light_brightness(value)
+        await self.async_request_refresh()
+
+    async def set_timer_duration(self, value: int) -> None:
+        await self.blueair_api_device.set_timer_duration(value)
+        await self.async_request_refresh()
+
+    async def set_hour_format(self, value: bool) -> None:
+        await self.blueair_api_device.set_hour_format(value)
         await self.async_request_refresh()

--- a/custom_components/ha_blueair/manifest.json
+++ b/custom_components/ha_blueair/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dahlb/ha_blueair/issues",
   "loggers": ["ha_blueair", "blueair_api"],
-  "requirements": ["blueair-api==1.50.4"],
+  "requirements": ["blueair-api==1.51.0"],
   "version": "1.48.1"
 }

--- a/custom_components/ha_blueair/mqtt_mapping.py
+++ b/custom_components/ha_blueair/mqtt_mapping.py
@@ -1,20 +1,11 @@
-def map_and_publish_sensor_data(sensors, device):
-    """Handle MQTT sensor data (called from MQTT thread)."""
-    if "pm1" in sensors:
-        device.pm1 = int(sensors["pm1"])
-    if "pm2_5" in sensors:
-        device.pm2_5 = int(sensors["pm2_5"])
-    if "pm10" in sensors:
-        device.pm10 = int(sensors["pm10"])
-    if "fsp0" in sensors:
-        device.fan_speed_0 = int(sensors["fsp0"])
-    if "t" in sensors:
-        device.temperature = int(sensors["t"])
-    if "h" in sensors:
-        device.humidity = int(sensors["h"])
-    if "tVOC" in sensors:
-        device.total_voc = int(sensors["tVOC"])
-    device.publish_updates()
+"""MQTT event mapping helpers.
+
+Sensor and shadow state updates are mapped by ``blueair_api`` itself
+(``DeviceAws.apply_sensor_data`` / ``DeviceAws.apply_state_change``).
+This module only handles MQTT connectivity events — the small set of
+``Connected``/``NotConnected`` payloads the library doesn't translate.
+"""
+
 
 def map_and_publish_event(event, device):
     event_type = event.get("et", "")
@@ -23,3 +14,4 @@ def map_and_publish_event(event, device):
     elif event_type == "NotConnected":
         device.wifi_working = False
     device.publish_updates()
+

--- a/custom_components/ha_blueair/sensor.py
+++ b/custom_components/ha_blueair/sensor.py
@@ -6,13 +6,16 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     UnitOfTemperature,
+    UnitOfTime,
     PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     CONCENTRATION_PARTS_PER_MILLION,
     CONCENTRATION_PARTS_PER_BILLION,
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
 )
 
 from .blueair_update_coordinator import BlueairUpdateCoordinator
+from .blueair_update_coordinator_device_aws import BlueairUpdateCoordinatorDeviceAws
 from .entity import BlueairEntity, async_setup_entry_helper
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -30,6 +33,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             BlueairWickLifeSensor,
             BlueairWaterRefresherLifeSensor,
             BlueairWaterLevelSensor,
+            BlueairRssiSensor,
+            BlueairTimerDurationSensor,
     ])
 
 
@@ -177,4 +182,49 @@ class BlueairWaterLevelSensor(BlueairSensor):
         native_unit_of_measurement=PERCENTAGE,
         suggested_display_precision=0,
         icon="mdi:waves",
+    )
+
+
+class BlueairRssiSensor(BlueairSensor):
+    """Monitors the Wi-Fi signal strength reported via MQTT (dBm).
+
+    RSSI arrives only via the MQTT 5s topic (the REST telemetry endpoint
+    does not return it), so the value is None at startup until the first
+    MQTT message lands.  Override is_implemented to check the schema-
+    declared sensor slugs instead of the current value, otherwise the
+    entity would never be created on REST-only devices or before the
+    first MQTT publish.
+    """
+    entity_description = SensorEntityDescription(
+        key="rssi",
+        name="Signal Strength",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        entity_registry_enabled_default=False,
+        suggested_display_precision=0,
+    )
+
+    @classmethod
+    def is_implemented(kls, coordinator):
+        if not isinstance(coordinator, BlueairUpdateCoordinatorDeviceAws):
+            return False
+        return "rssi" in (coordinator.blueair_api_device.mqtt_sensor_slugs or [])
+
+
+class BlueairTimerDurationSensor(BlueairSensor):
+    """Monitors the configured sleep / off timer duration (seconds).
+
+    Populated from REST states[] during refresh(), so the value is
+    available at startup on devices that ship a sleep timer (humidifiers,
+    Mini Restful).  is_implemented falls back to the schema check on
+    fresh devices where refresh() hasn't completed yet.
+    """
+    entity_description = SensorEntityDescription(
+        key="timer_duration",
+        name="Timer Duration",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        entity_registry_enabled_default=False,
+        suggested_display_precision=0,
+        icon="mdi:timer-outline",
     )


### PR DESCRIPTION
Phase 2 of [#334](https://github.com/dahlb/ha_blueair/issues/334).
Depends on `blueair-api` 1.51.0 (PR
[dahlb/blueair_api#131](https://github.com/dahlb/blueair_api/pull/131),
merged and released).

## Problem

Three issues with how MQTT data reaches Home Assistant entities. The
first was partly addressed by ca1fe0d ("feat: add temperature,
humidity, voc to mqtt listener") shortly before this PR; the other
two are still open on `main`.

1. **Hardcoded sensor field list scales poorly.** `__init__.py`
   currently has a chain of `if "pm1" in sensors / if "pm2_5" in
   sensors / ...` blocks — expanded most recently in ca1fe0d to cover
   humidifier `t`, `h`, and `tVOC`. Each new device or firmware
   feature that ships a new MQTT slug requires another `if` branch
   here, plus another duplicate attribute write in the library's
   `refresh()`. This PR consolidates the slug-to-attribute mapping
   into the library so the integration just calls
   `device.apply_sensor_data(sensors)` and every known slug — plus
   any future ones we add — propagates the same way.

2. **The `on_state_change` callback was never wired.** When the
   Blueair firmware pushes a shadow update (e.g., fan speed changed
   via the physical button or another app), the library fires
   `on_state_change(device_id, state)` — but `ha_blueair` doesn't set
   that callback. State changes only propagate on the next 5-minute
   REST poll.

3. **Adding a new sensor field meant editing 5 places.** Every new
   slug required: a map entry / `if`-branch in the integration, a
   `DeviceAws` attribute, a `refresh()` line in the library, a
   coordinator `@property`, and a new entity class. The library PR
   (Phase 1) consolidates the first three; this PR completes the
   wiring at the integration layer.

## Changes

### `__init__.py` — wire MQTT callbacks to the library

Replaces the hardcoded sensor mapping block with the library's new
`apply_sensor_data()` method, and registers an `on_state_change`
callback that calls `apply_state_change()`. Both are wrapped in
`try/except` so a malformed payload doesn't kill the MQTT thread:

```python
def on_sensor_data(device_id, sensors):
    coordinator = aws_coordinator_map.get(device_id)
    if coordinator is None:
        return
    device = coordinator.blueair_api_device
    try:
        device.apply_sensor_data(sensors)
    except Exception:
        _LOGGER.exception(
            "apply_sensor_data raised for device %s with payload %r",
            device_id, sensors,
        )
        return
    device.publish_updates()
    hass.loop.call_soon_threadsafe(
        coordinator.async_set_updated_data, str(device)
    )

def on_state_change(device_id, state):
    # symmetric wiring; calls device.apply_state_change(state)
    ...

mqtt_client.on_sensor_data = on_sensor_data
mqtt_client.on_state_change = on_state_change
```

The existing `map_and_publish_event` helper (handles
`Connected` / `NotConnected` connectivity events) is kept unchanged.
The sensor-mapping half of `mqtt_mapping.py` is now redundant with the
library and has been removed; the module docstring explains the
split.

### Coordinator — 5 new properties + 3 new setters

`blueair_update_coordinator_device_aws.py` gains read-through
properties for `rssi`, `night_light_brightness`, `timer_state`,
`timer_duration`, and `hour_format`, plus async setters for the three
user-controllable fields. Same pattern as existing properties.

### Two new sensor entities

| Entity | Source | Default |
|---|---|---|
| `BlueairRssiSensor` | `coordinator.rssi` (dBm) | Disabled |
| `BlueairTimerDurationSensor` | `coordinator.timer_duration` (seconds) | Disabled |

Both are gated behind schema-based `is_implemented` checks:

- **RSSI** checks `"rssi" in coordinator.blueair_api_device.mqtt_sensor_slugs`
  — needed because RSSI only arrives via MQTT (the REST telemetry
  endpoint doesn't include it), so `coordinator.rssi` would be
  `NotImplemented` at `async_setup_entry` time on a value-based check
  and the entity would never be created.
- **Timer Duration** uses the standard value-based check
  (`coordinator.timer_duration is not NotImplemented`) since it's
  populated from REST `states[]` at refresh time.

Both are **disabled by default** so they don't clutter user
dashboards — users opt in via Settings → Devices & Services →
Blueair → Entities.

## Testing

Live-tested for 24 hours on a Blue Max 211i:

| Metric | Value |
|---|---|
| Window | May 10 08:34 → May 11 05:17 UTC |
| Total sensor messages | **14,840** |
| Minutes with continuous data | **1,244 / 1,244 (100%)** |
| Data gaps (>1 min) | **0** |
| MQTT reconnects | 20 (hourly) |
| Failed reconnects | **0** |
| `Id Token Expired` errors | **0** |
| Unmapped MQTT slug events | **0** |
| Unmapped shadow slug events | 3 (`cfv`/`mfv`/`ofv` firmware versions — cosmetic, will follow up) |
| Unexpected ERROR/WARN lines | **0** |

Schema announcement appears once on startup (debug-level):

```
DEBUG Device 14ad6685... declares MQTT 5s sensor slugs:
      ['pm2_5', 'fsp0', 'rssi', 'pm1', 'pm10']
```

`ruff check .` clean.

## Compatibility

- Existing `on_sensor_data` callback behavior is preserved — every
  slug the recent ca1fe0d commit hardcoded (`pm1`, `pm2_5`, `pm10`,
  `fsp0`, `t`, `h`, `tVOC`) is in `MQTT_SENSOR_FIELD_MAP` and applied
  identically. This PR replaces the `if` chain with a single call to
  the library; no behavioral regression for the slugs ca1fe0d already
  handled, and `rssi` is newly applied for any device whose schema
  declares it.
- Existing `on_event` connectivity handling is preserved unchanged.
- The only visible change for current users is two new
  disabled-by-default sensors (`Signal Strength`, `Timer Duration`).
- No `unique_id` changes; no entity migrations needed.

## Version

- `manifest.json`: `blueair-api==1.50.4` → `blueair-api==1.51.0`
- `manifest.json`: integration `version` field intentionally left
  unchanged at `1.48.1` — version bumps are owned by the release
  script (same convention applied in dahlb/blueair_api#131).

## Files

- `custom_components/ha_blueair/__init__.py` — wire callbacks, +
  try/except wrappers (+34 -10)
- `custom_components/ha_blueair/blueair_update_coordinator_device_aws.py`
  — 5 properties, 3 setters (+32)
- `custom_components/ha_blueair/sensor.py` — 2 new entity classes,
  RSSI schema check (+50)
- `custom_components/ha_blueair/mqtt_mapping.py` — remove redundant
  sensor mapping helper, keep connectivity event helper (+8 -19)
- `custom_components/ha_blueair/manifest.json` — `blueair-api`
  requirement bump (+1 -1)

## Companion PR

Library work in
[dahlb/blueair_api#131](https://github.com/dahlb/blueair_api/pull/131)
(merged and released as `blueair-api` 1.51.0).

## Adding a new device model after this lands

For a device that ships a slug we don't recognise yet (e.g. a future
purifier with a `co2` MQTT field, or a humidifier with a `humsetpoint`
shadow control), the workflow is now:

1. **Capture a debug log** from a user with the device to see which
   slugs land in `DEBUG ... not in MQTT_SENSOR_FIELD_MAP` /
   `... not in SHADOW_FIELD_MAP` messages.

2. **For each new slug**, in `blueair_api` (`device_aws.py`):
   - Add the slug → attr-name entry to `MQTT_SENSOR_FIELD_MAP` or
     `SHADOW_FIELD_MAP`.
   - Add the matching `AttributeType[T]` field to the `DeviceAws`
     dataclass.
   - If the field is also in the REST `states[]` array, add a
     `self.<attr> = states_safe_get("<slug>")` line in `refresh()`.
   - For user-controllable fields, add an `async def set_<attr>(...)`
     setter that calls `api.set_device_info`.
   - Add fixture-test assertions (the `assert_fully_checked` guard
     forces this).
   - Release `blueair-api` minor.

3. **For each user-visible entity**, in `ha_blueair`:
   - Add a `@property` to `BlueairUpdateCoordinatorDeviceAws` that
     reads the new attribute (and any unit conversion / scaling).
   - Add a setter on the coordinator if writable.
   - Add an entity class to the matching platform file
     (`sensor.py`, `binary_sensor.py`, `switch.py`, etc.) with
     `is_implemented` gated either on `coordinator.<attr> is not
     NotImplemented` (REST-backed) or on `"<slug>" in
     coordinator.blueair_api_device.mqtt_sensor_slugs`
     (MQTT-only, like `BlueairRssiSensor`).
   - Bump the `manifest.json` `blueair-api` requirement.

Compared to before this PR, steps 2c (`refresh()` line) and 3a
(coordinator property) are still needed, but step 3 — the entity
class — is now the only place where the slug-to-HA mapping lives
on the integration side; the slug-to-attribute mapping is purely
library-side and reusable for any consumer.

The full mechanical refactor (step 3 becoming automatic too) is
tracked as Phase 3 of #334 — auto-discovery from
`configuration.dc`/`da`/`ds`. Out of scope for this PR.

## Follow-ups (out of scope)

- **Mini Restful entity expansion** — read-only timer-state /
  sunrise-brightness / clock-format sensors, then writable
  `number`/`select` controls. Tracked on philjn's side; will file a
  separate issue once this lands.
- **Phase 3 of #334** — schema-driven entity discovery from
  `configuration.dc`/`da`/`ds` so future device models work without
  code changes. Issue draft ready.
- **#347** — event-loop-closed teardown race during integration
  reloads. Independent fix in a separate branch (already filed).

## Ref

- Closes Phase 2 of #334
- Depends on dahlb/blueair_api#131 (merged, released as 1.51.0)
