### PR TITLE
fix: bool(NotImplemented) crashes climate platform on Python 3.14

### DIFF
--- a/custom_components/ha_blueair/climate.py
+++ b/custom_components/ha_blueair/climate.py
@@ -28,6 +28,26 @@ FAN_SPEED_BY_STEP: dict[str, int] = {
 }
 
 
+def _safe_int(value: object, default: int = 0) -> int:
+    """Coerce a coordinator value to int, treating None / NotImplemented / unparseable as ``default``.
+
+    Coordinator properties on BlueairUpdateCoordinatorDeviceAws return
+    ``int``, ``None``, or the ``NotImplemented`` sentinel (per the
+    library's ``AttributeType[T]``). The naive ``int(x or 0)`` idiom is
+    wrong because ``NotImplemented`` is truthy, so the ``or 0``
+    short-circuit never fires; on Python 3.9-3.13 ``bool(NotImplemented)``
+    emitted ``DeprecationWarning`` and returned ``True``, on Python 3.14+
+    it raises ``TypeError`` (matching the upstream fix for #354 in
+    humidifier.py).
+    """
+    if value is None or value is NotImplemented:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 async def async_setup_entry(hass, config_entry: ConfigEntry, async_add_entities):
     async_setup_entry_helper(
         hass,
@@ -112,7 +132,7 @@ class BlueairThermostat(BlueairEntity, ClimateEntity):
         if self.coordinator.is_on is False:
             return HVACMode.OFF
 
-        match int(self.coordinator.main_mode or 0):
+        match _safe_int(self.coordinator.main_mode):
             case 0:
                 return HVACMode.FAN_ONLY
             case 1:
@@ -123,12 +143,12 @@ class BlueairThermostat(BlueairEntity, ClimateEntity):
 
     def _coordinator_fan_mode(self, hvac: HVACMode | None) -> str | None:
         if hvac == HVACMode.FAN_ONLY:
-            if int(self.coordinator.ap_sub_mode or 0) == 2:
+            if _safe_int(self.coordinator.ap_sub_mode) == 2:
                 return FanMode.AUTO.value
             return _fan_mode_from_speed(self.coordinator.fan_speed_0)
 
         if hvac == HVACMode.HEAT:
-            if int(self.coordinator.heat_sub_mode or 0) == 2:
+            if _safe_int(self.coordinator.heat_sub_mode) == 2:
                 return FanMode.AUTO.value
             return _fan_mode_from_speed(self.coordinator.heat_fan_speed)
 


### PR DESCRIPTION
Follow-up to #354. The fix there addressed humidifier.py; climate.py has three additional sites with the same anti-pattern that crash on Python 3.14 (which now raises TypeError on bool(NotImplemented), per the deprecation that landed in 3.9).

Sites fixed (all in BlueairThermostat):

* _coordinator_hvac_mode: int(main_mode or 0)

* _coordinator_fan_mode (FAN_ONLY): int(ap_sub_mode or 0) == 2

* _coordinator_fan_mode (HEAT): int(heat_sub_mode or 0) == 2

The naive 'int(x or 0)' idiom is wrong because NotImplemented is truthy, so 'or 0' never fires. On 3.9-3.13 this emitted DeprecationWarning and silently returned the wrong type to int(); on 3.14+ it raises TypeError. The hvac_mode site was guarded by is_implemented so it was latent; the sub_mode sites are reachable on any T10i schema that does not declare apsubmode/heatsubmode in dc.

Replaces all three with a new _safe_int(value, default=0) helper that explicitly treats None and NotImplemented as the default before trying int(). Idiom matches the upstream pattern @dahlb introduced in 9a9b3ed for the humidifier mode property.

No behavior change on Python 3.9-3.13 for happy-path values (the wrong-type-to-int call returned the same numeric result via truthiness coincidence). On 3.14+ this prevents the climate entity from crashing on T10i variants that omit apsubmode / heatsubmode.