### PR TITLE
fix: sensor platform crash that breaks all sensors on accounts with both legacy and AWS device records (#356)

### DIFF
--- a/custom_components/ha_blueair/binary_sensor.py
+++ b/custom_components/ha_blueair/binary_sensor.py
@@ -20,7 +20,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class BlueairBinarySensor(BlueairEntity, BinarySensorEntity):
     @classmethod
     def is_implemented(kls, coordinator: BlueairUpdateCoordinator) -> bool:
-        return getattr(coordinator, kls(coordinator).entity_description.key) is not NotImplemented
+        # See sensor.BlueairSensor.is_implemented (issue #356) for rationale
+        # on the NotImplemented default.
+        return getattr(coordinator, kls(coordinator).entity_description.key, NotImplemented) is not NotImplemented
 
     def __init__(self, coordinator):
         """Initialize the temperature sensor."""

--- a/custom_components/ha_blueair/blueair_update_coordinator.py
+++ b/custom_components/ha_blueair/blueair_update_coordinator.py
@@ -245,6 +245,37 @@ class BlueairUpdateCoordinator(ABC, DataUpdateCoordinator):
     def auto_regulated_humidity(self) -> bool | None | NotImplemented:
         pass
 
+    # ----- AWS-only sensor attributes (issue #356) -----
+    # Declared abstract so any subclass MUST provide a value (legacy
+    # subclasses return NotImplemented).  Prevents the v1.49.0 regression
+    # where AWS-only properties weren't stubbed on the legacy coordinator,
+    # causing AttributeError in sensor is_implemented() checks.
+
+    @property
+    @abstractmethod
+    def timer_duration(self) -> int | None | NotImplemented:
+        pass
+
+    @property
+    @abstractmethod
+    def timer_state(self) -> int | None | NotImplemented:
+        pass
+
+    @property
+    @abstractmethod
+    def rssi(self) -> int | None | NotImplemented:
+        pass
+
+    @property
+    @abstractmethod
+    def night_light_brightness(self) -> int | None | NotImplemented:
+        pass
+
+    @property
+    @abstractmethod
+    def hour_format(self) -> bool | None | NotImplemented:
+        pass
+
     async def set_fan_speed(self, new_speed) -> None:
         await self.blueair_api_device.set_fan_speed(new_speed)
         await self.async_request_refresh()

--- a/custom_components/ha_blueair/blueair_update_coordinator_device.py
+++ b/custom_components/ha_blueair/blueair_update_coordinator_device.py
@@ -119,6 +119,31 @@ class BlueairUpdateCoordinatorDevice(BlueairUpdateCoordinator):
             return NotImplemented
         return self.blueair_api_device.fan_auto_mode
 
+    # ----- Stubs for AWS-only sensor attributes (issue #356) -----
+    # The legacy REST device does not expose these fields, but the
+    # abstract base requires every subclass to declare them so that
+    # entity is_implemented() checks can safely call getattr().
+
+    @property
+    def timer_duration(self) -> int | None | NotImplemented:
+        return NotImplemented
+
+    @property
+    def timer_state(self) -> int | None | NotImplemented:
+        return NotImplemented
+
+    @property
+    def rssi(self) -> int | None | NotImplemented:
+        return NotImplemented
+
+    @property
+    def night_light_brightness(self) -> int | None | NotImplemented:
+        return NotImplemented
+
+    @property
+    def hour_format(self) -> bool | None | NotImplemented:
+        return NotImplemented
+
     @property
     def wick_dry_mode(self) -> bool | None | NotImplemented:
         return NotImplemented

--- a/custom_components/ha_blueair/sensor.py
+++ b/custom_components/ha_blueair/sensor.py
@@ -43,7 +43,12 @@ class BlueairSensor(BlueairEntity, SensorEntity):
 
     @classmethod
     def is_implemented(kls, coordinator):
-        return getattr(coordinator, kls(coordinator).entity_description.key) is not NotImplemented
+        # Use NotImplemented as the default so a coordinator that doesn't even
+        # declare this attribute (e.g. an AWS-only property on the legacy
+        # coordinator class) is treated as "not implemented" instead of
+        # raising AttributeError, which would abort the whole sensor platform.
+        # See issue #356.
+        return getattr(coordinator, kls(coordinator).entity_description.key, NotImplemented) is not NotImplemented
 
     def __init__(self, coordinator: BlueairUpdateCoordinator):
         """Initialize the temperature sensor."""
@@ -214,10 +219,12 @@ class BlueairRssiSensor(BlueairSensor):
 class BlueairTimerDurationSensor(BlueairSensor):
     """Monitors the configured sleep / off timer duration (seconds).
 
-    Populated from REST states[] during refresh(), so the value is
-    available at startup on devices that ship a sleep timer (humidifiers,
-    Mini Restful).  is_implemented falls back to the schema check on
-    fresh devices where refresh() hasn't completed yet.
+    AWS-only.  ``timer_duration`` is populated from REST ``states[]``
+    during refresh(), so the value is available shortly after startup on
+    devices that ship a sleep timer (humidifiers, Mini Restful).  The
+    legacy ``Device`` API has no concept of a sleep timer, so this
+    entity is restricted to AWS coordinators via :py:meth:`is_implemented`
+    (mirrors :class:`BlueairRssiSensor`).
     """
     entity_description = SensorEntityDescription(
         key="timer_duration",
@@ -228,3 +235,12 @@ class BlueairTimerDurationSensor(BlueairSensor):
         suggested_display_precision=0,
         icon="mdi:timer-outline",
     )
+
+    @classmethod
+    def is_implemented(kls, coordinator):
+        # AWS-only entity: the legacy Device class does not model a sleep
+        # timer at all.  Guard explicitly so this entity is never offered
+        # for a legacy coordinator (issue #356).
+        if not isinstance(coordinator, BlueairUpdateCoordinatorDeviceAws):
+            return False
+        return super().is_implemented(coordinator)


### PR DESCRIPTION
Closes #356.

## Problem

Since v1.49.0, users with certain account configurations have lost all sensor readings (Filter Life, PM 2.5, etc.) on AWS-backed devices like the Pure 511i Max. The sensors show as `Unavailable` instead of streaming data.

From [#356](https://github.com/dahlb/ha_blueair/issues/356) debug logs, the root error is:

```
ERROR (MainThread) [homeassistant.components.sensor] Error while setting up
ha_blueair platform for sensor: 'BlueairUpdateCoordinatorDevice' object has
no attribute 'timer_duration'
  File "/config/custom_components/ha_blueair/sensor.py", line 23, in async_setup_entry
  File "/config/custom_components/ha_blueair/entity.py", line 21, in async_setup_entry_helper
  File "/config/custom_components/ha_blueair/sensor.py", line 46, in is_implemented
```

The `AttributeError` propagates out of `async_setup_entry_helper`, aborting the **entire** sensor platform setup — so every sensor on every device for that account ends up missing, not just the timer.

## Root cause

v1.49.0 (PR #352 / commit df34ed9) added `BlueairTimerDurationSensor` and wired `timer_duration` into `BlueairUpdateCoordinatorDeviceAws` only. The default `BlueairSensor.is_implemented` does:

```python
return getattr(coordinator, kls(coordinator).entity_description.key) is not NotImplemented
```

When that runs against the legacy `BlueairUpdateCoordinatorDevice` (which has no `timer_duration` attribute at all), `getattr` raises `AttributeError` instead of returning `NotImplemented`, and the platform setup aborts.

Users hit this whenever their account returns both a legacy ABL record *and* an AWS record for the same physical fan — observable in #356's log as two coordinators (`ha_blueair-HappyBot` finishing in 0.265s and `ha_blueair-None` finishing in 0.946s) for what is in fact a single 511i Max.

## The fix

Four small, independently-defensible changes:

### 1. Defensive `getattr` default in `BlueairSensor.is_implemented` and `BlueairBinarySensor.is_implemented`

`custom_components/ha_blueair/sensor.py` and `custom_components/ha_blueair/binary_sensor.py`:

```diff
-return getattr(coordinator, kls(coordinator).entity_description.key) is not NotImplemented
+return getattr(coordinator, kls(coordinator).entity_description.key, NotImplemented) is not NotImplemented
```

A missing attribute is now treated as "not implemented" instead of raising `AttributeError`. This alone resolves #356.

### 2. `BlueairTimerDurationSensor` is now AWS-only

`custom_components/ha_blueair/sensor.py` — override `is_implemented` to require an AWS coordinator, mirroring the pattern already used by `BlueairRssiSensor`:

```python
@classmethod
def is_implemented(kls, coordinator):
    if not isinstance(coordinator, BlueairUpdateCoordinatorDeviceAws):
        return False
    return super().is_implemented(coordinator)
```

The legacy `Device` API has no concept of a sleep timer, so this entity should never have been offered for legacy coordinators in the first place.

### 3. `NotImplemented` stubs on the legacy coordinator

`custom_components/ha_blueair/blueair_update_coordinator_device.py` — add stubs for the five v1.49.0 AWS-only attributes that have no legacy equivalent:

- `timer_duration`
- `timer_state`
- `rssi`
- `night_light_brightness`
- `hour_format`

Each returns `NotImplemented`, matching the existing pattern used by `filter_life`, `wick_life`, `mood_brightness`, etc.

### 4. Abstract-base hardening

`custom_components/ha_blueair/blueair_update_coordinator.py` — declare those same five names as `@property @abstractmethod` on `BlueairUpdateCoordinator`. Python's ABC machinery will now refuse to instantiate any subclass that forgets a stub, surfacing the bug at startup with a clear `TypeError` instead of crashing the sensor platform later.

This is the single highest-leverage change: it makes the entire class of regression (AWS-only attribute added without a legacy stub) impossible to ship in the future.

## Validation

- `ruff check custom_components/ha_blueair` — clean.
- `python -m compileall custom_components/ha_blueair` — clean.
- Sanity script with stubbed coordinator shapes confirms:
  - the abstract base declares all five new attrs as `@abstractmethod`,
  - both subclasses instantiate (i.e. each provides concrete overrides),
  - `is_implemented` no longer raises `AttributeError` on legacy coordinators for any of the entity classes,
  - `BlueairTimerDurationSensor.is_implemented(legacy)` → `False`,
  - `BlueairTimerDurationSensor.is_implemented(aws, timer_duration=300)` → `True`,
  - `BlueairTimerDurationSensor.is_implemented(aws, timer_duration=NotImplemented)` → `False`.
- Live-tested for 9 hours on a 211i Max account that returns a single AWS coordinator (no dual listing). Zero ha_blueair errors or warnings in the HA log, integration setup completes cleanly, MQTT sensor stream is continuous. The dual-coordinator path that #356 actually reproduces is verified via the sanity script and reasoning (we could not reproduce the dual listing locally, since it is account-specific behavior on Blueair's side).

## Why ship this regardless of dual listings

The four changes are strictly defensive — never widen the surface, only narrow the failure modes:

1. The bug is a regression in the abstraction itself, not a workaround for a single user. Before v1.49.0, the implicit contract was "any attribute a sensor's `is_implemented` checks must exist on both coordinator classes." v1.49.0 broke that contract.
2. The defensive `getattr(..., NotImplemented)` costs nothing and removes the failure mode where a future contributor adds an AWS-only attribute without remembering to stub the legacy side.
3. The `@abstractmethod` declarations turn a tribal rule into an enforced invariant — preferring startup `TypeError` over runtime `AttributeError`.

## Out of scope (tracked as follow-ups)

- **Tests.** `ha_blueair` does not currently have a `tests/` directory. The plan is a separate PR that bootstraps pytest scaffolding and adds (a) a direct regression test for #356 and (b) an `inspect`-based invariant test that walks every `@abstractmethod` on `BlueairUpdateCoordinator` and asserts both subclasses override it. The invariant test would have caught this bug before v1.49.0 shipped.
- **`BlueairEntity.device_info` `mac is None` tolerance.** #356's log also shows `ValueError("MAC address is required for device info")` from `binary_sensor` and `fan` setup, caused by the legacy ABL record having `mac: null`. That existed before v1.49.0 but became more visible once sensors broke. Separate issue + PR.
- **De-duplicate ABL + AWS coordinators.** The actual root cause underneath #356 is that we create two coordinators per physical fan whenever Blueair has the same device registered in both backends. Filtering legacy entries whose `uuid` is also in the AWS set in `__init__.async_setup_entry` is a larger behavioral change and deserves its own issue. Targeted for a future minor release.
