### PR TITLE
fix: tolerate mac=None in BlueairEntity.device_info (closes #361)

### DIFF
--- a/custom_components/ha_blueair/entity.py
+++ b/custom_components/ha_blueair/entity.py
@@ -1,4 +1,6 @@
 """Base entity class for Blueair entities."""
+import logging
+
 from propcache import cached_property
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -8,6 +10,13 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import DOMAIN, DATA_DEVICES, DATA_AWS_DEVICES
 from .blueair_update_coordinator_device import BlueairUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Module-level set of coordinator UUIDs we've already warned about for a
+# missing MAC.  Keeps the log from spamming once per entity (~10 entities
+# per coordinator).  See the issue linked in `device_info` below.
+_MAC_MISSING_WARNED: set[str] = set()
 
 
 def async_setup_entry_helper(hass, config_entry, async_add_entities, entity_classes):
@@ -45,9 +54,27 @@ class BlueairEntity(CoordinatorEntity[BlueairUpdateCoordinator]):
 
     @cached_property[DeviceInfo | None]
     def device_info(self) -> DeviceInfo:
-        if self.coordinator.blueair_api_device.mac is None:
-            raise ValueError("MAC address is required for device info")
-        connections = {(CONNECTION_NETWORK_MAC, self.coordinator.blueair_api_device.mac)}
+        # Some Blueair API responses (notably the legacy ABL device list
+        # for accounts where the same device is also AWS-registered) carry
+        # `mac: null`.  Falling back to identifiers-only keeps the entity
+        # registerable instead of raising and aborting the platform.
+        # See dahlb/ha_blueair#356 for the original symptom.
+        mac = self.coordinator.blueair_api_device.mac
+        if mac is None:
+            uuid = self.coordinator.id
+            if uuid not in _MAC_MISSING_WARNED:
+                _MAC_MISSING_WARNED.add(uuid)
+                _LOGGER.warning(
+                    "Blueair device %s (%s) reported mac=None; registering "
+                    "device by identifier only.  This usually means the "
+                    "device appears in both the legacy and AWS device lists "
+                    "for this account.",
+                    self.coordinator.device_name,
+                    uuid,
+                )
+            connections: set[tuple[str, str]] = set()
+        else:
+            connections = {(CONNECTION_NETWORK_MAC, mac)}
         return DeviceInfo(
             connections=connections,
             identifiers={(DOMAIN, self.coordinator.id)},


### PR DESCRIPTION
# Tolerate `mac=None` in `BlueairEntity.device_info`

Closes #361. Related to #356 (separate root cause, this is the secondary failure mode seen in #356's log).

## Problem

When a Blueair account returns the same physical device in both the legacy ABL device list and the new AWS device list, the legacy entry's `mac` field can be `null`. `BlueairEntity.device_info` currently raises `ValueError("MAC address is required for device info")` for every entity backed by that coordinator, which propagates out of entity registration and aborts the affected platform setup.

Visible in #356's debug log on every restart:

```
2026-05-15 11:09:11.093 ERROR (MainThread) [homeassistant.components.binary_sensor] Error adding entity None for domain binary_sensor with platform ha_blueair
  File "/config/custom_components/ha_blueair/entity.py", line 49, in device_info
...
2026-05-15 11:09:11.096 ERROR (MainThread) [homeassistant.components.fan] Error adding entity None for domain fan with platform ha_blueair
  File "/config/custom_components/ha_blueair/entity.py", line 49, in device_info
```

The condition predates v1.49.0 but became more visible after the sensor platform regression that v1.49.3 fixes (`fix: restore sensor platform when account returns both legacy and AWS device records (#356)`).

## Fix

When `coordinator.blueair_api_device.mac` is `None`, fall back to a `DeviceInfo` populated with `identifiers` only — drop `connections=`. Log a single `WARNING` per coordinator UUID surfacing the situation without spamming the log (a coordinator backs ~10 entities, so a per-entity warning would multiply by 10).

```python
mac = self.coordinator.blueair_api_device.mac
if mac is None:
    uuid = self.coordinator.id
    if uuid not in _MAC_MISSING_WARNED:
        _MAC_MISSING_WARNED.add(uuid)
        _LOGGER.warning(
            "Blueair device %s (%s) reported mac=None; registering "
            "device by identifier only.  ...",
            self.coordinator.device_name, uuid,
        )
    connections: set[tuple[str, str]] = set()
else:
    connections = {(CONNECTION_NETWORK_MAC, mac)}
return DeviceInfo(
    connections=connections,
    identifiers={(DOMAIN, self.coordinator.id)},
    ...
)
```

## Behaviour change

- Entities for a `mac=None` coordinator now register successfully instead of failing setup.
- HA's device registry accepts identifiers-only `DeviceInfo`; the device will appear as normal but cannot auto-merge with other integrations via a shared MAC address (which it could not do anyway when `mac=None`).
- One `WARNING` is logged per affected coordinator per HA restart, e.g.:
  > Blueair device HappyBot (1fe2ea40-9c23-4b06-b270-1948555e36a9) reported mac=None; registering device by identifier only. This usually means the device appears in both the legacy and AWS device lists for this account.

## Validation

- `ruff check custom_components/ha_blueair` — clean.
- `python -m compileall custom_components/ha_blueair` — clean.
- I could not reproduce the dual-listing scenario locally (my test 211i Max account only returns an AWS coordinator), so the fix is verified via code review and reasoning rather than a live regression test. The reporter on #356 sees the underlying condition daily and can confirm via debug log inspection once v1.49.x with this fix is released.

## Out of scope

The underlying root cause — duplicate ABL + AWS coordinators for one physical device — is a separate issue that deserves its own fix (filter the legacy device list against the AWS UUID set in `async_setup_entry`). Will file as a follow-up. This PR is purely about not crashing when the dual listing exists.
