### PR TITLE
feat: expose Signature/SP4i fan preset modes via apsubmode

### DIFF
--- a/custom_components/ha_blueair/const.py
+++ b/custom_components/ha_blueair/const.py
@@ -42,3 +42,16 @@ DEFAULT_FAN_SPEED_PERCENTAGE = 50
 MODE_FAN_SPEED = "fan_speed"
 MODE_AUTO = "auto"
 MODE_NIGHT = "night"
+
+# Additional preset modes used by Blueair Signature-series air
+# purifiers (SP1i / SP3i / SP4i, type_name='blue40', hw='l_blue40'),
+# which expose all four preset modes through the `apsubmode` shadow
+# field rather than `automode` / `nightmode`. See issues
+# dahlb/ha_blueair#348 and #261.
+#
+# The integer wire values for these labels live in
+# `blueair_api.AP_SUB_MODE_LABELS` so the library can stay the
+# single source of truth for the apsubmode namespace (see also
+# Phase 3 tracking in dahlb/ha_blueair#353).
+MODE_MANUAL_FAN = "manual_fan"
+MODE_ECO = "eco"

--- a/custom_components/ha_blueair/fan.py
+++ b/custom_components/ha_blueair/fan.py
@@ -1,17 +1,42 @@
 """Support for Blueair fans."""
 from __future__ import annotations
 
+import logging
 from asyncio import sleep
 from homeassistant.components.fan import (
     FanEntity,
     FanEntityFeature,
 )
 
+from blueair_api import AP_SUB_MODE_LABELS
+
 from .blueair_update_coordinator import BlueairUpdateCoordinator
-from .const import DEFAULT_FAN_SPEED_PERCENTAGE, MODE_AUTO, MODE_NIGHT
+from .const import (
+    DEFAULT_FAN_SPEED_PERCENTAGE,
+    MODE_AUTO,
+    MODE_MANUAL_FAN,
+    MODE_NIGHT,
+)
 from .blueair_update_coordinator_device import BlueairUpdateCoordinatorDevice
 from .blueair_update_coordinator_device_aws import BlueairUpdateCoordinatorDeviceAws
 from .entity import BlueairEntity, async_setup_entry_helper
+
+_LOGGER = logging.getLogger(__name__)
+
+# Reverse lookup for AP_SUB_MODE_LABELS: HA preset label -> apsubmode
+# wire value. Built once at import time; the library guarantees keys
+# are ints and values are unique (see test_labels_are_unique).
+_LABEL_TO_AP_SUB_MODE: dict[str, int] = {
+    label: value for value, label in AP_SUB_MODE_LABELS.items()
+}
+
+# Investigation of the Blueair cloud API responses and AWS IoT
+# protocol behavior shows that Signature-family devices pair every
+# `apsubmode` write with a `fanspeed` reset to this value (the
+# device's lowest manual speed). Mirroring the pattern keeps the
+# device's stored manual fan speed at a known low value, so
+# returning to manual_fan later starts at a predictable speed.
+_SIGNATURE_APSUBMODE_FANSPEED_RESET = 11
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -122,13 +147,53 @@ class BlueairAwsFan(BlueairEntity, FanEntity):
     def is_implemented(kls, coordinator):
         return isinstance(coordinator, BlueairUpdateCoordinatorDeviceAws)
 
+    @staticmethod
+    def _supports_signature_presets(coordinator) -> bool:
+        """True for Blueair Signature-series devices that switch presets
+        via ``apsubmode`` (no ``automode`` / ``nightmode`` shadow fields).
+
+        Currently observed on SP4i (and assumed on SP1i / SP3i — same
+        ``blue40`` / ``l_blue40`` capability shape). The library's
+        ``AP_SUB_MODE_LABELS`` is intentionally Signature-only;
+        T10i / pet_air_pro / 2-in-1 declare ``automode`` and so are
+        excluded by this gate — see the constant's docstring in
+        ``blueair_api/device_aws.py``.
+
+        Issues: dahlb/ha_blueair#348 and #261.
+        """
+        return (
+            coordinator.ap_sub_mode is not NotImplemented
+            and coordinator.fan_auto_mode is NotImplemented
+            and coordinator.night_mode is NotImplemented
+        )
+
     def __init__(self, coordinator: BlueairUpdateCoordinatorDeviceAws):
         """Initialize the fan entity."""
+        self._signature_presets = self._supports_signature_presets(coordinator)
+
+        if self._signature_presets:
+            # One-shot at entity creation so a debug-log session can
+            # answer "did this device enter the Signature preset path?"
+            # without polling state. Fires once per entity instance
+            # (typically once at HA startup / integration reload).
+            _LOGGER.debug(
+                "BlueairAwsFan(%s): Signature preset modes enabled "
+                "(model=%s, presets=%s)",
+                getattr(coordinator.blueair_api_device, "uuid", "?"),
+                coordinator.model,
+                list(AP_SUB_MODE_LABELS.values()),
+            )
+
         self._attr_preset_modes = []
-        if coordinator.fan_auto_mode is not NotImplemented:
-            self._attr_preset_modes.append(MODE_AUTO)
-        if coordinator.night_mode is not NotImplemented:
-            self._attr_preset_modes.append(MODE_NIGHT)
+        if self._signature_presets:
+            # Signature devices: four presets derived from
+            # AP_SUB_MODE_LABELS (manual_fan / auto / night / eco).
+            self._attr_preset_modes = list(AP_SUB_MODE_LABELS.values())
+        else:
+            if coordinator.fan_auto_mode is not NotImplemented:
+                self._attr_preset_modes.append(MODE_AUTO)
+            if coordinator.night_mode is not NotImplemented:
+                self._attr_preset_modes.append(MODE_NIGHT)
 
         self._attr_supported_features = FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
         if coordinator.fan_speed is not NotImplemented:
@@ -145,12 +210,51 @@ class BlueairAwsFan(BlueairEntity, FanEntity):
     @property
     def percentage(self) -> int | None:
         """Return the current speed percentage."""
+        if self._signature_presets:
+            # On Signature devices the user only sees a meaningful speed
+            # value while in manual_fan (apsubmode=0). In auto/night/eco
+            # the device picks the speed and the percentage UI is
+            # actively misleading.
+            ap_sub_mode = self.coordinator.ap_sub_mode
+            if ap_sub_mode in (None, NotImplemented):
+                manual = True
+            else:
+                try:
+                    manual = int(ap_sub_mode) == _LABEL_TO_AP_SUB_MODE[MODE_MANUAL_FAN]
+                except (TypeError, ValueError):
+                    manual = True
+            if not manual:
+                return None
+            if self.coordinator.fan_speed in (None, NotImplemented):
+                return None
+            return int((self.coordinator.fan_speed * 100) // self.coordinator.speed_count)
+
         if self.preset_mode is None:
           return int((self.coordinator.fan_speed * 100) // self.coordinator.speed_count)
         else:
           return None
 
     async def async_set_percentage(self, percentage: int) -> None:
+        if self._signature_presets:
+            # Switch into manual_fan first so the device honors the
+            # percentage write. Skipped if already there to avoid an
+            # extraneous shadow write on every speed change.
+            manual_value = _LABEL_TO_AP_SUB_MODE[MODE_MANUAL_FAN]
+            ap_sub_mode = self.coordinator.ap_sub_mode
+            try:
+                already_manual = (
+                    ap_sub_mode not in (None, NotImplemented)
+                    and int(ap_sub_mode) == manual_value
+                )
+            except (TypeError, ValueError):
+                already_manual = False
+            if not already_manual:
+                await self.coordinator.set_ap_sub_mode(manual_value)
+            blueair_percentage = int(round(percentage / 100 * self.coordinator.speed_count))
+            await self.coordinator.set_fan_speed(blueair_percentage)
+            self.async_write_ha_state()
+            return
+
         if self.coordinator.fan_auto_mode is True:
             await self.coordinator.set_fan_auto_mode(False)
         if self.coordinator.night_mode is True:
@@ -163,6 +267,31 @@ class BlueairAwsFan(BlueairEntity, FanEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
+        if self._signature_presets:
+            value = _LABEL_TO_AP_SUB_MODE.get(preset_mode)
+            if value is None:
+                # HA frontend validates against preset_modes before
+                # calling us, so this only fires when an automation
+                # or service call sends an unknown label. Surface it
+                # at debug level so the user can diagnose without
+                # having to enable trace-level logging on HA core.
+                _LOGGER.debug(
+                    "BlueairAwsFan: ignoring unknown preset_mode=%r "
+                    "(known: %s)",
+                    preset_mode, list(_LABEL_TO_AP_SUB_MODE),
+                )
+                return
+            await self.coordinator.set_ap_sub_mode(value)
+            # Investigation of the Blueair cloud API responses and AWS
+            # IoT protocol behavior shows that apsubmode writes on
+            # Signature-family devices are paired with a fanspeed
+            # reset (see _SIGNATURE_APSUBMODE_FANSPEED_RESET docstring).
+            # The slider is hidden in non-manual presets, so this write
+            # is invisible while the preset is active.
+            await self.coordinator.set_fan_speed(_SIGNATURE_APSUBMODE_FANSPEED_RESET)
+            self.async_write_ha_state()
+            return
+
         if preset_mode == MODE_AUTO:
             await self.coordinator.set_fan_auto_mode(True)
         elif preset_mode == MODE_NIGHT:
@@ -203,6 +332,15 @@ class BlueairAwsFan(BlueairEntity, FanEntity):
     @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., auto, smart, interval, favorite."""
+        if self._signature_presets:
+            ap_sub_mode = self.coordinator.ap_sub_mode
+            if ap_sub_mode in (None, NotImplemented):
+                return None
+            try:
+                return AP_SUB_MODE_LABELS.get(int(ap_sub_mode))
+            except (TypeError, ValueError):
+                return None
+
         if self.coordinator.fan_auto_mode is True:
             return MODE_AUTO
         if self.coordinator.night_mode is True:

--- a/custom_components/ha_blueair/icons.json
+++ b/custom_components/ha_blueair/icons.json
@@ -5,8 +5,10 @@
         "state_attributes": {
           "preset_mode": {
             "state": {
+              "manual_fan": "mdi:fan-speed-1",
               "auto": "mdi:fan-auto",
-              "night": "mdi:weather-night"
+              "night": "mdi:weather-night",
+              "eco": "mdi:leaf"
             }
           }
         }

--- a/custom_components/ha_blueair/manifest.json
+++ b/custom_components/ha_blueair/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dahlb/ha_blueair/issues",
   "loggers": ["ha_blueair", "blueair_api"],
-  "requirements": ["blueair-api==1.51.0"],
+  "requirements": ["blueair-api==1.52.0"],
   "version": "1.49.4"
 }

--- a/custom_components/ha_blueair/strings.json
+++ b/custom_components/ha_blueair/strings.json
@@ -46,8 +46,10 @@
         "state_attributes": {
           "preset_mode": {
             "state": {
+              "manual_fan": "Manual",
               "auto": "Auto",
-              "night": "Night"
+              "night": "Night",
+              "eco": "Eco"
             }
           }
         }

--- a/custom_components/ha_blueair/translations/en.json
+++ b/custom_components/ha_blueair/translations/en.json
@@ -46,8 +46,10 @@
         "state_attributes": {
           "preset_mode": {
             "state": {
+              "manual_fan": "Manual",
               "auto": "Auto",
-              "night": "Night"
+              "night": "Night",
+              "eco": "Eco"
             }
           }
         }


### PR DESCRIPTION
Closes #348 and #261. Adds four Home Assistant fan preset modes (manual_fan / auto / night / eco) for Blueair Signature-series air purifiers (SP1i / SP3i / SP4i, type_name='blue40', hw='l_blue40'), which switch presets via the 'apsubmode' shadow field rather than the legacy 'automode' / 'nightmode' fields.

Detection: a capability gate on BlueairAwsFan, '_supports_signature_presets', returns True iff the coordinator exposes ap_sub_mode AND does NOT expose fan_auto_mode / night_mode. T10i / pet_air_pro / 2-in-1 declare 'automode' and so are excluded; their existing fan-platform behavior is unchanged.

Wire-value to preset-label map (0=manual_fan, 2=auto, 3=night, 4=eco) lives in blueair_api.AP_SUB_MODE_LABELS (added in blueair-api v1.52.0). The integration imports it directly so the library stays the single source of truth for the apsubmode namespace and Phase 3 schema-driven entity discovery (#353) can reuse the same dict.

Behavior on the Signature path:

* fan_modes lists all four presets.

* preset_mode reads AP_SUB_MODE_LABELS[ap_sub_mode]; None when unknown.

* set_preset_mode writes the corresponding apsubmode value, paired with a fanspeed reset to the device's lowest manual speed (matches the protocol pattern so returning to manual_fan later starts at a predictable speed).

* set_percentage writes apsubmode=0 (manual_fan) first when not already there, then fanspeed.

* percentage returns the live speed only while in manual_fan; None in auto/night/eco where the device chooses the speed.

Diagnostic logging: one DEBUG line per Signature entity at __init__ stating that the Signature path is enabled (uuid, model, presets). One DEBUG line in async_set_preset_mode if an unknown preset label is requested (only fires from buggy automations). No spam on hot paths.

UX polish: strings.json / translations/en.json / icons.json updated to add labels and icons for the new 'manual_fan' and 'eco' presets so the HA fan card shows 'Manual', 'Auto', 'Night', 'Eco' with appropriate mdi icons.

Out-of-scope: roomtype, airrefresh, hover, displaymode controls on Signature devices, deferred to Phase 3 (#353) schema-driven entity discovery.