### PR TITLE
Support beta / pre-release builds in the Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,16 @@ on:
   push:
     branches:
       - main
+  # Manual pre-release path. Run this workflow from the Actions tab, pick the
+  # branch you want to cut the build from, and supply a pre-release version
+  # such as "1.51.0-beta.1". Leaving the input blank reproduces the normal
+  # stable release behaviour.
+  workflow_dispatch:
+    inputs:
+      prerelease_version:
+        description: 'Pre-release version, e.g. 1.51.0-beta.1 (blank = normal stable release from main)'
+        required: false
+        default: ''
 permissions:
   contents: write
   deployments: write
@@ -11,37 +21,66 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      # Stable path: derive the next version from the conventional-commit history.
+      # Skipped when an explicit pre-release version is supplied via dispatch.
       - name: Gets semantic release info
         id: semantic_release_info
+        if: ${{ github.event.inputs.prerelease_version == '' }}
         uses: jossef/action-semantic-release-info@v3.0.0
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Update Version and Commit
-        if: ${{steps.semantic_release_info.outputs.version != ''}}
+      - name: Resolve release metadata
+        id: meta
         run: |
-          echo "Version: ${{steps.semantic_release_info.outputs.version}}"
-          sed -i "s/\"version\": \".*\"/\"version\": \"${{steps.semantic_release_info.outputs.version}}\"/g" custom_components/ha_blueair/manifest.json 
+          INPUT_VERSION="${{ github.event.inputs.prerelease_version }}"
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+            NOTES="Pre-release build ${VERSION}. Available to HACS users who enable \"Show beta versions\"."
+          else
+            VERSION="${{ steps.semantic_release_info.outputs.version }}"
+            NOTES="${{ steps.semantic_release_info.outputs.notes }}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "git_tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          # Mark the GitHub Release as a pre-release automatically whenever the
+          # version carries an -alpha / -beta / -rc suffix. HACS only surfaces
+          # pre-releases to users who opt in via "Show beta versions".
+          if echo "$VERSION" | grep -Eiq -- '-(alpha|beta|rc)'; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+          {
+            echo "notes<<RELEASE_NOTES_EOF"
+            echo "$NOTES"
+            echo "RELEASE_NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Update Version and Commit
+        if: ${{ steps.meta.outputs.version != '' }}
+        run: |
+          echo "Version: ${{ steps.meta.outputs.version }}"
+          sed -i "s/\"version\": \".*\"/\"version\": \"${{ steps.meta.outputs.version }}\"/g" custom_components/ha_blueair/manifest.json 
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git diff
           git add -A
-          git commit -m "chore: bumping version to ${{steps.semantic_release_info.outputs.version}}"
-          git tag ${{ steps.semantic_release_info.outputs.git_tag }}
+          git commit -m "chore: bumping version to ${{ steps.meta.outputs.version }}"
+          git tag ${{ steps.meta.outputs.git_tag }}
       - name: Push changes
-        if: ${{steps.semantic_release_info.outputs.version != ''}}
+        if: ${{ steps.meta.outputs.version != '' }}
         uses: ad-m/github-push-action@v1.3.0
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           branch: ${{ github.ref }}
           tags: true
       - name: Create GitHub Release
-        if: ${{steps.semantic_release_info.outputs.version != ''}}
+        if: ${{ steps.meta.outputs.version != '' }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
-          tag_name: ${{ steps.semantic_release_info.outputs.git_tag }}
-          release_name: ${{ steps.semantic_release_info.outputs.git_tag }}
-          body: ${{ steps.semantic_release_info.outputs.notes }}
+          tag_name: ${{ steps.meta.outputs.git_tag }}
+          release_name: ${{ steps.meta.outputs.git_tag }}
+          body: ${{ steps.meta.outputs.notes }}
           draft: false
-          prerelease: false
+          prerelease: ${{ steps.meta.outputs.prerelease }}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,51 @@ A custom integration for Blueair Filters.  If your model isn't reported correctl
 ## Installation ##
 You can install this either manually copying files or using HACS. Configuration can be done on UI, you need to enter your username and password, (I know, translations are missing).
 
+## Beta / Pre-release Builds ##
+
+Some changes are easier to validate with a small group of opt-in testers before
+they ship to everyone. Those changes are published as **pre-release** builds that
+only appear for users who have turned on beta versions in HACS. Normal users are
+never offered a pre-release and stay on the latest stable build.
+
+### Installing a beta as a tester (HACS) ###
+
+1. In Home Assistant, open **HACS** and find **Blueair Filters** under
+   Integrations.
+2. Open the three-dot menu on the integration and choose **Redownload**
+   (some HACS versions label this **Update information** / **Reinstall**).
+3. Enable the **Show beta versions** toggle in that dialog.
+4. Pick the beta version (for example `1.51.0-beta.1`) from the version list and
+   download it.
+5. Restart Home Assistant.
+
+To return to a stable build, repeat the steps with **Show beta versions** turned
+off, select the latest non-beta version, and restart.
+
+> When reporting on a beta, include the exact version string and a diagnostics
+> download (see [Troubleshooting](#troubleshooting-)) so issues are easy to trace.
+
+### Publishing a beta (maintainers) ###
+
+Stable releases are unchanged: a push to `main` runs the **Release** workflow,
+which derives the next version from the conventional-commit history and publishes
+a normal (non-pre-release) GitHub Release.
+
+Pre-releases are cut manually from a feature branch so they never reach stable
+users:
+
+1. Push the change to a feature branch (do **not** merge to `main` yet).
+2. Go to **Actions -> Release -> Run workflow**.
+3. Select that feature branch as the workflow ref.
+4. In **Pre-release version**, enter a version with a suffix, e.g.
+   `1.51.0-beta.1` (the suffix may be `-alpha`, `-beta`, or `-rc`).
+5. Run it. The workflow bumps `manifest.json` on that branch, tags
+   `v1.51.0-beta.1`, and creates a GitHub Release that is **automatically marked
+   as a pre-release** because of the suffix. HACS then offers it only to users
+   with **Show beta versions** enabled.
+
+When validation is complete, merge the branch to `main`; the normal push-to-main
+flow then publishes the stable version the usual way.
 ## Limitations ##
 If you receive an error while trying to login, try resetting your password to one with no special characters except '!' and no longer then 10 characters.
 


### PR DESCRIPTION
## Summary

Adds an opt-in **pre-release** path to the existing Release workflow so changes
that are hard to verify centrally can be field-tested by a small group of beta
users before they ship to everyone. The normal stable release flow is unchanged.

This is the CI groundwork discussed in **#312** — it lets the CP7i
region-pairing / region-discovery fix go out as a `-beta` build that only opt-in
HACS testers receive, so it can be validated on real accounts and hardware
before it lands in a stable release.

## What changes

- **New manual trigger:** the Release workflow gains a `workflow_dispatch` entry
  with a single optional input, `prerelease_version` (e.g. `1.51.0-beta.1`).
- **Stable path is untouched:** a push to `main` still runs semantic-release and
  publishes a normal, non-pre-release GitHub Release exactly as before. The
  semantic-release step is simply skipped when a manual version is supplied.
- **Automatic pre-release flagging:** if the version carries an `-alpha`,
  `-beta`, or `-rc` suffix (case-insensitive), the GitHub Release is created with
  `prerelease: true`. HACS only surfaces those builds to users who enable
  **Show beta versions**; everyone else stays on stable.
- **No new dependencies / secrets.** Same actions, same `GITHUB_TOKEN`.
- **README:** adds a _Beta / Pre-release Builds_ section with step-by-step
  instructions for testers (HACS "Show beta versions" → pick the beta → restart)
  and for maintainers (push a feature branch → Actions → Release → Run workflow →
  enter a suffixed version).

## How a maintainer cuts a beta

1. Push the change to a feature branch (do **not** merge to `main` yet).
2. **Actions → Release → Run workflow**, select that branch as the ref.
3. Enter a suffixed **Pre-release version**, e.g. `1.51.0-beta.1`.
4. The workflow bumps `manifest.json` on that branch, tags `v1.51.0-beta.1`, and
   publishes a GitHub Release auto-marked as a pre-release.
5. When validation is done, merge the branch to `main`; the usual push-to-main
   flow ships the stable version.

## Testing

Validated end-to-end on a fork (artifacts since removed):

- Dispatched the workflow from a feature branch with `1.99.0-beta.1`.
- Confirmed it bumped `manifest.json`, created tag `v1.99.0-beta.1`, and the
  resulting GitHub Release had `isPrerelease: true`, `isDraft: false`.
- Confirmed the stable push-to-main path is unaffected: with a blank input the
  semantic-release step runs and produces a normal release (verified the
  suffix-detection logic returns `prerelease=false` for plain `X.Y.Z` versions
  and `true` for `-alpha/-beta/-rc`, case-insensitive).

## Suggested rollout for #312

1. Merge this CI PR to `main` first so `workflow_dispatch` becomes available.
2. Open the region-discovery integration change as its own feature branch
   (leave it unmerged).
3. Dispatch **Release** with that branch + version `1.51.0-beta.1`.
4. Beta testers validate on real accounts/hardware.
5. Merge to `main` → stable ships the usual way.

## Notes / out of scope

- While testing I noticed the existing `actions/create-release@v1` step emits the
  `set-output` deprecation warning (and a Node 20 deprecation notice). That's
  pre-existing and unrelated to this change — happy to follow up separately by
  switching to `softprops/action-gh-release@v2` if you'd like, but I kept this PR
  minimal and focused.
