### PR TITLE
feat: add BlueCloud device cloud region selection (CP7i)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,22 @@ never offered a pre-release and stay on the latest stable build.
 
 ### Installing a beta as a tester (HACS) ###
 
+Recent HACS versions removed the separate "Show beta versions" toggle and moved
+the beta/pre-release selection into the download dialog:
+
 1. In Home Assistant, open **HACS** and find **Blueair Filters** under
    Integrations.
-2. Open the three-dot menu on the integration and choose **Redownload**
-   (some HACS versions label this **Update information** / **Reinstall**).
-3. Enable the **Show beta versions** toggle in that dialog.
-4. Pick the beta version (for example `1.51.0-beta.1`) from the version list and
-   download it.
-5. Restart Home Assistant.
+2. Click the integration to open its repository page.
+3. In the top-right corner, open the kebab menu (**⋮**).
+4. Choose **Redownload**.
+5. Select **Need a different version?**.
+6. A list of available releases appears — including beta, pre-release, or dev
+   versions if the repository publishes them. Pick the beta version (for example
+   `1.51.0-beta.1`) and confirm.
+7. Restart Home Assistant.
 
-To return to a stable build, repeat the steps with **Show beta versions** turned
-off, select the latest non-beta version, and restart.
+To return to a stable build, repeat the steps and select the latest non-beta
+version, then restart.
 
 > When reporting on a beta, include the exact version string and a diagnostics
 > download (see [Troubleshooting](#troubleshooting-)) so issues are easy to trace.
@@ -77,8 +82,8 @@ users:
    `1.51.0-beta.1` (the suffix may be `-alpha`, `-beta`, or `-rc`).
 5. Run it. The workflow bumps `manifest.json` on that branch, tags
    `v1.51.0-beta.1`, and creates a GitHub Release that is **automatically marked
-   as a pre-release** because of the suffix. HACS then offers it only to users
-   with **Show beta versions** enabled.
+   as a pre-release** because of the suffix. HACS then offers it only to testers
+   who explicitly pick it via **Redownload → Need a different version?**.
 
 When validation is complete, merge the branch to `main`; the normal push-to-main
 flow then publishes the stable version the usual way.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,56 @@ users:
 
 When validation is complete, merge the branch to `main`; the normal push-to-main
 flow then publishes the stable version the usual way.
+
+## Account Region and Device Cloud Region ##
+
+Most Blueair accounts use the same region for account login and device control.
+For those accounts, keep the suggested values during setup.
+
+Some devices are hosted on a different BlueCloud region than the account login
+region. During setup, the integration detects the account region automatically,
+then checks the Blueair cloud for the likely device cloud region. If there is
+one clear region with online devices, setup saves it automatically. If the
+result is ambiguous, setup asks you to choose the device cloud region. The
+selected device cloud region is stored in the config entry and reused on every
+startup.
+
+You can change both the account region and device cloud region later from the
+integration's Configure menu if a device appears offline or stale.
+
+Initial setup flow:
+
+```text
+Blueair Account
+  -> Enter username and password
+  -> Integration detects the account region
+  -> Integration checks for the likely Device cloud region
+  -> Creates the entry automatically if one online region is clear
+  -> Otherwise asks you to choose the Device cloud region
+```
+
+If an existing entry appears to be using the wrong device cloud region, Home
+Assistant can show a repair issue. The repair flow checks again, suggests a
+device cloud region, and reloads the integration after you confirm the value.
+
+Repair flow:
+
+```text
+Repair issue
+  -> Fix
+  -> Confirm Device cloud region
+  -> Integration reloads with the selected cloud region
+```
+
+Screenshot checklist for release notes / README updates:
+
+- Initial setup: Account credentials step
+- Initial setup: Account region picker, if more than one account region works
+- Initial setup: Automatic completion when one online device cloud region is clear
+- Initial setup: Device cloud region picker when discovery is ambiguous
+- Repair issue: Cloud region may be incorrect
+- Repair flow: Device cloud region confirmation
+
 ## Limitations ##
 If you receive an error while trying to login, try resetting your password to one with no special characters except '!' and no longer then 10 characters.
 

--- a/custom_components/ha_blueair/__init__.py
+++ b/custom_components/ha_blueair/__init__.py
@@ -12,16 +12,25 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.typing import ConfigType
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from blueair_api import get_devices, get_aws_devices, LoginError, MqttAwsBlueair
+from blueair_api import (
+    device_state_looks_frozen,
+    get_devices,
+    get_aws_devices,
+    LoginError,
+    MqttAwsBlueair,
+)
 
 from .mqtt_mapping import map_and_publish_event
 from .blueair_update_coordinator_device import BlueairUpdateCoordinatorDevice
 from .blueair_update_coordinator_device_aws import BlueairUpdateCoordinatorDeviceAws
 from .const import (
     DOMAIN,
+    CONF_CLOUD_REGION,
+    REPAIR_CLOUD_REGION_MISMATCH,
     PLATFORMS,
     DATA_DEVICES,
     DATA_AWS_DEVICES,
@@ -31,6 +40,46 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _cloud_region_issue_id(config_entry: ConfigEntry) -> str:
+    return f"{REPAIR_CLOUD_REGION_MISMATCH}_{config_entry.entry_id}"
+
+
+def _async_update_cloud_region_repair_issue(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    coordinators: list[BlueairUpdateCoordinatorDeviceAws],
+    cloud_region: str,
+) -> None:
+    issue_id = _cloud_region_issue_id(config_entry)
+
+    for coordinator in coordinators:
+        raw_info = getattr(coordinator.blueair_api_device, "raw_info", None)
+        if not device_state_looks_frozen(raw_info):
+            continue
+
+        device_name = coordinator.device_name or coordinator.id
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=REPAIR_CLOUD_REGION_MISMATCH,
+            translation_placeholders={
+                "device_name": device_name,
+                "cloud_region": cloud_region,
+            },
+            data={
+                "entry_id": config_entry.entry_id,
+                "device_id": coordinator.id,
+                "device_name": device_name,
+            },
+        )
+        return
+
+    ir.async_delete_issue(hass, DOMAIN, issue_id)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -52,8 +101,19 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
     if config_entry.version == 1:
         new_data = {**config_entry.data, CONF_REGION: REGION_USA}
 
-        config_entry.version = 2
-        hass.config_entries.async_update_entry(config_entry, data=new_data)
+        hass.config_entries.async_update_entry(
+            config_entry, data=new_data, version=2
+        )
+
+    if config_entry.version == 2:
+        new_data = {
+            **config_entry.data,
+            CONF_CLOUD_REGION: config_entry.data.get(CONF_REGION, REGION_USA),
+        }
+
+        hass.config_entries.async_update_entry(
+            config_entry, data=new_data, version=3
+        )
 
     _LOGGER.info("Migration to version %s successful", config_entry.version)
 
@@ -70,7 +130,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     _LOGGER.debug(f"async setup entry: {config_entry}")
     username = config_entry.data[CONF_USERNAME]
     password = config_entry.data[CONF_PASSWORD]
-    region = config_entry.data[CONF_REGION]
+    region = config_entry.options.get(CONF_REGION, config_entry.data[CONF_REGION])
+    cloud_region = config_entry.options.get(
+        CONF_CLOUD_REGION,
+        config_entry.data.get(CONF_CLOUD_REGION, region),
+    )
     interval = config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
     _LOGGER.debug(f"setting up scan interval: {interval}")
 
@@ -89,7 +153,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
             username=username,
             password=password,
             client_session=client_session,
-            region=region,
+            gigya_region=region,
+            cloud_region=cloud_region,
         )
 
         def create_coordinators(device):
@@ -112,6 +177,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         for coordinator in coordinators:
             await coordinator.async_config_entry_first_refresh()
 
+        _async_update_cloud_region_repair_issue(
+            hass,
+            config_entry,
+            data[DATA_AWS_DEVICES],
+            cloud_region,
+        )
+
         # Start MQTT for real-time updates on AWS devices.
         mqtt_client = None
         if (
@@ -122,7 +194,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         ):
             try:
                 mqtt_client = MqttAwsBlueair(
-                    region=region,
+                    region=cloud_region,
                     mqtt_auth_name=aws_http_client.mqtt_auth_name,
                     mqtt_auth_signature=aws_http_client.mqtt_auth_signature,
                     mqtt_auth_token=aws_http_client.mqtt_auth_token,

--- a/custom_components/ha_blueair/config_flow.py
+++ b/custom_components/ha_blueair/config_flow.py
@@ -238,6 +238,21 @@ class ConfigFlowHandler(config_entries.ConfigFlow):
         except Exception:
             _LOGGER.debug("BlueCloud region discovery failed", exc_info=True)
         else:
+            _LOGGER.debug(
+                "BlueCloud region discovery: selected=%s winner=%s "
+                "multi_region=%s per_region=%s",
+                scan.selected_region,
+                scan.winner,
+                scan.multi_region_detected,
+                {
+                    region_key: {
+                        "devices": probe.device_count,
+                        "online": probe.online_count,
+                        "error": probe.error,
+                    }
+                    for region_key, probe in scan.per_region.items()
+                },
+            )
             if scan.winner is not None:
                 self._cloud_region_default = scan.winner
                 self._cloud_region_source = "online devices found in this region"
@@ -247,8 +262,25 @@ class ConfigFlowHandler(config_entries.ConfigFlow):
                     if probe.online_count and probe.online_count > 0
                 ]
                 if len(online_regions) == 1:
+                    _LOGGER.debug(
+                        "BlueCloud region discovery: auto-selecting %s "
+                        "(only online region)",
+                        scan.winner,
+                    )
                     self.data[CONF_CLOUD_REGION] = scan.winner
                     return await self._async_create_blueair_entry()
+                _LOGGER.debug(
+                    "BlueCloud region discovery: not auto-selecting "
+                    "(online_regions=%s); prompting user with default %s",
+                    online_regions,
+                    self._cloud_region_default,
+                )
+            else:
+                _LOGGER.debug(
+                    "BlueCloud region discovery: no winner; prompting user "
+                    "with default %s",
+                    self._cloud_region_default,
+                )
         finally:
             if api_cloud is not None:
                 await api_cloud.cleanup_client_session()

--- a/custom_components/ha_blueair/config_flow.py
+++ b/custom_components/ha_blueair/config_flow.py
@@ -10,18 +10,36 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
 )
 from homeassistant.core import callback
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 
 from .const import (
     DOMAIN,
+    CONF_CLOUD_REGION,
     CONFIG_FLOW_VERSION,
     REGIONS,
     REGION_USA,
     DEFAULT_SCAN_INTERVAL,
 )
 
-from blueair_api import AuthError, get_aws_devices
+from blueair_api import AuthError, HttpAwsBlueair
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _region_selector(options: list[str] | None = None):
+    return SelectSelector(
+        SelectSelectorConfig(
+            options=options or REGIONS,
+            mode=SelectSelectorMode.DROPDOWN,
+        )
+    )
+
+
+REGION_SELECTOR = _region_selector()
 
 
 class OptionFlowHandler(config_entries.OptionsFlow):
@@ -29,8 +47,24 @@ class OptionFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Display preferences UI."""
+        region = config_entry.options.get(
+            CONF_REGION,
+            config_entry.data.get(CONF_REGION, REGION_USA),
+        )
+        cloud_region = config_entry.options.get(
+            CONF_CLOUD_REGION,
+            config_entry.data.get(CONF_CLOUD_REGION, region),
+        )
         self.schema = vol.Schema(
             {
+                vol.Required(
+                    CONF_REGION,
+                    default=region,
+                ): REGION_SELECTOR,
+                vol.Required(
+                    CONF_CLOUD_REGION,
+                    default=cloud_region,
+                ): REGION_SELECTOR,
                 vol.Required(
                     CONF_SCAN_INTERVAL,
                     default=config_entry.options.get(
@@ -55,8 +89,6 @@ class ConfigFlowHandler(config_entries.ConfigFlow):
     VERSION = CONFIG_FLOW_VERSION
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_PUSH
 
-    data: dict[str, Any] | None = {}
-
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
@@ -64,40 +96,161 @@ class ConfigFlowHandler(config_entries.ConfigFlow):
         return OptionFlowHandler(config_entry)
 
     def __init__(self):
-        pass
+        self.data: dict[str, Any] = {}
+        self._account_region_candidates: list[str] = []
+        self._cloud_region_default = REGION_USA
+        self._cloud_region_source = "defaulted to account region"
+
+    async def _async_create_blueair_entry(self):
+        username = self.data[CONF_USERNAME]
+        await self.async_set_unique_id(username)
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(
+            title=username,
+            data=self.data,
+        )
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
         data_schema = {
-            vol.Required(
-                CONF_REGION,
-                default=REGION_USA,
-            ): vol.In(REGIONS),
             vol.Required(CONF_USERNAME): str,
             vol.Required(CONF_PASSWORD): str,
         }
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            region = user_input[CONF_REGION]
             username = user_input[CONF_USERNAME]
             password = user_input[CONF_PASSWORD]
 
-            api_cloud = None
-            try:
-                api_cloud, _devices = await get_aws_devices(username=username, password=password, region=region)
-                self.data.update(user_input)
-                await self.async_set_unique_id(username)
-                self._abort_if_unique_id_configured()
-                return self.async_create_entry(
-                    title=username,
-                    data=self.data,
-                )
-            except AuthError:
+            self.data = {
+                CONF_USERNAME: username,
+                CONF_PASSWORD: password,
+            }
+            account_regions = await self._async_detect_account_regions(
+                username, password
+            )
+            if not account_regions:
                 errors["base"] = "auth"
-            finally:
-                if api_cloud is not None:
-                    await api_cloud.cleanup_client_session()
+            elif len(account_regions) == 1:
+                region = account_regions[0]
+                self.data[CONF_REGION] = region
+                return await self._async_prepare_cloud_region_step(region)
+            else:
+                self._account_region_candidates = account_regions
+                return await self.async_step_account_region()
 
         return self.async_show_form(
             step_id="user", data_schema=vol.Schema(data_schema), errors=errors
         )
+
+    async def async_step_account_region(
+        self, user_input: dict[str, Any] | None = None
+    ):
+        if user_input is not None:
+            region = user_input[CONF_REGION]
+            self.data[CONF_REGION] = region
+            return await self._async_prepare_cloud_region_step(region)
+
+        options = self._account_region_candidates or REGIONS
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_REGION,
+                    default=options[0],
+                ): _region_selector(options),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="account_region", data_schema=data_schema, errors={}
+        )
+
+    async def async_step_cloud_region(
+        self, user_input: dict[str, Any] | None = None
+    ):
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            self.data[CONF_CLOUD_REGION] = user_input[CONF_CLOUD_REGION]
+            return await self._async_create_blueair_entry()
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_CLOUD_REGION,
+                    default=self._cloud_region_default,
+                ): REGION_SELECTOR,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="cloud_region",
+            data_schema=data_schema,
+            errors=errors,
+            description_placeholders={
+                "suggested_cloud_region": self._cloud_region_default,
+                "suggestion_source": self._cloud_region_source,
+            },
+        )
+
+    async def _async_detect_account_regions(
+        self, username: str, password: str
+    ) -> list[str]:
+        account_regions: list[str] = []
+        for region in REGIONS:
+            api_cloud = None
+            try:
+                api_cloud = HttpAwsBlueair(
+                    username=username,
+                    password=password,
+                    gigya_region=region,
+                    cloud_region=region,
+                )
+                await api_cloud.refresh_jwt()
+            except AuthError:
+                _LOGGER.debug("Blueair account auth failed for region %s", region)
+            except Exception:
+                _LOGGER.debug(
+                    "Blueair account-region detection failed for %s",
+                    region,
+                    exc_info=True,
+                )
+            else:
+                account_regions.append(region)
+            finally:
+                if api_cloud is not None:
+                    await api_cloud.cleanup_client_session()
+        return account_regions
+
+    async def _async_prepare_cloud_region_step(self, region: str):
+        self._cloud_region_default = region
+        self._cloud_region_source = "defaulted to account region"
+
+        api_cloud = None
+        try:
+            api_cloud = HttpAwsBlueair(
+                username=self.data[CONF_USERNAME],
+                password=self.data[CONF_PASSWORD],
+                gigya_region=region,
+                cloud_region=region,
+            )
+            await api_cloud.refresh_jwt()
+            scan = await api_cloud.discover_cloud_region()
+        except Exception:
+            _LOGGER.debug("BlueCloud region discovery failed", exc_info=True)
+        else:
+            if scan.winner is not None:
+                self._cloud_region_default = scan.winner
+                self._cloud_region_source = "online devices found in this region"
+                online_regions = [
+                    region_key
+                    for region_key, probe in scan.per_region.items()
+                    if probe.online_count and probe.online_count > 0
+                ]
+                if len(online_regions) == 1:
+                    self.data[CONF_CLOUD_REGION] = scan.winner
+                    return await self._async_create_blueair_entry()
+        finally:
+            if api_cloud is not None:
+                await api_cloud.cleanup_client_session()
+
+        return await self.async_step_cloud_region()

--- a/custom_components/ha_blueair/const.py
+++ b/custom_components/ha_blueair/const.py
@@ -5,7 +5,9 @@ from homeassistant.const import Platform
 DOMAIN: str = "ha_blueair"
 
 # Integration Setting Constants
-CONFIG_FLOW_VERSION: int = 2
+CONFIG_FLOW_VERSION: int = 3
+CONF_CLOUD_REGION: str = "cloud_region"
+REPAIR_CLOUD_REGION_MISMATCH: str = "cloud_region_mismatch"
 DEFAULT_SCAN_INTERVAL: int = 5
 PLATFORMS = [
     Platform.BINARY_SENSOR,

--- a/custom_components/ha_blueair/manifest.json
+++ b/custom_components/ha_blueair/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dahlb/ha_blueair/issues",
   "loggers": ["ha_blueair", "blueair_api"],
-  "requirements": ["blueair-api==1.52.0"],
+  "requirements": ["blueair-api==1.53.0"],
   "version": "1.50.0"
 }

--- a/custom_components/ha_blueair/repairs.py
+++ b/custom_components/ha_blueair/repairs.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from blueair_api import AuthError, HttpAwsBlueair
+from homeassistant import data_entry_flow
+from homeassistant.const import CONF_PASSWORD, CONF_REGION, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
+
+from .const import CONF_CLOUD_REGION, DOMAIN, REGIONS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+REGION_SELECTOR = SelectSelector(
+    SelectSelectorConfig(
+        options=REGIONS,
+        mode=SelectSelectorMode.DROPDOWN,
+    )
+)
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant, issue_id: str, data: dict[str, Any] | None
+) -> data_entry_flow.FlowHandler:
+    return BlueairCloudRegionRepairFlow(hass, issue_id, data or {})
+
+
+class BlueairCloudRegionRepairFlow(data_entry_flow.FlowHandler):
+    VERSION = 1
+
+    def __init__(
+        self, hass: HomeAssistant, issue_id: str, issue_data: dict[str, Any]
+    ) -> None:
+        self.hass = hass
+        self._issue_id = issue_id
+        self._issue_data = issue_data
+        self._suggested_cloud_region: str | None = None
+
+    async def async_step_init(self, user_input: dict[str, Any] | None = None):
+        entry_id = self._issue_data.get("entry_id")
+        config_entry = self.hass.config_entries.async_get_entry(entry_id)
+        if config_entry is None:
+            return self.async_abort(reason="entry_not_found")
+
+        current_cloud_region = config_entry.data.get(
+            CONF_CLOUD_REGION, config_entry.data[CONF_REGION]
+        )
+
+        if user_input is not None:
+            new_data = {
+                **config_entry.data,
+                CONF_CLOUD_REGION: user_input[CONF_CLOUD_REGION],
+            }
+            self.hass.config_entries.async_update_entry(config_entry, data=new_data)
+            ir.async_delete_issue(self.hass, DOMAIN, self._issue_id)
+            await self.hass.config_entries.async_reload(config_entry.entry_id)
+            return self.async_create_entry(title="", data={})
+
+        errors: dict[str, str] = {}
+        suggested_cloud_region = self._suggested_cloud_region
+        if suggested_cloud_region is None:
+            suggested_cloud_region = current_cloud_region
+            try:
+                suggested_cloud_region = await self._async_discover_cloud_region(
+                    config_entry, current_cloud_region
+                )
+            except AuthError:
+                errors["base"] = "auth"
+            except Exception:
+                _LOGGER.debug("BlueCloud repair discovery failed", exc_info=True)
+            self._suggested_cloud_region = suggested_cloud_region
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_CLOUD_REGION,
+                        default=suggested_cloud_region,
+                    ): REGION_SELECTOR,
+                }
+            ),
+            errors=errors,
+            description_placeholders={
+                "cloud_region": current_cloud_region,
+                "suggested_cloud_region": suggested_cloud_region,
+            },
+        )
+
+    async def _async_discover_cloud_region(
+        self, config_entry, current_cloud_region: str
+    ) -> str:
+        api_cloud = HttpAwsBlueair(
+            username=config_entry.data[CONF_USERNAME],
+            password=config_entry.data[CONF_PASSWORD],
+            gigya_region=config_entry.data[CONF_REGION],
+            cloud_region=current_cloud_region,
+        )
+        try:
+            await api_cloud.refresh_jwt()
+            scan = await api_cloud.discover_cloud_region()
+        finally:
+            await api_cloud.cleanup_client_session()
+
+        return scan.winner or current_cloud_region

--- a/custom_components/ha_blueair/strings.json
+++ b/custom_components/ha_blueair/strings.json
@@ -2,12 +2,25 @@
   "config": {
     "step": {
       "user": {
-        "title": "BlueAir Auth",
-        "description": "Configure your Credentials.",
+        "title": "Blueair Account",
+        "description": "Enter your Blueair account credentials.",
         "data": {
-          "region": "Region",
           "username": "Username",
           "password": "Password"
+        }
+      },
+      "account_region": {
+        "title": "Blueair Account Region",
+        "description": "More than one Blueair account region accepted these credentials. Choose the account region you normally use to sign in.",
+        "data": {
+          "region": "Account region"
+        }
+      },
+      "cloud_region": {
+        "title": "Blueair Device Cloud Region",
+        "description": "We could not choose a single device cloud region automatically. Suggested value: {suggested_cloud_region}. Source: {suggestion_source}. Choose the region for the device you want this entry to control. These options can be changed in the integration configuration.",
+        "data": {
+          "cloud_region": "Device cloud region"
         }
       },
       "reauth_confirm": {
@@ -19,11 +32,36 @@
       "auth": "Login failed. Please use official app to logout and log back in and try again."
     }
   },
+  "issues": {
+    "cloud_region_mismatch": {
+      "title": "Blueair device cloud region may be incorrect",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Confirm Blueair device cloud region",
+            "description": "The current device cloud region is {cloud_region}. Select the region to use for device control. The suggested value is {suggested_cloud_region}.",
+            "data": {
+              "cloud_region": "Device cloud region"
+            }
+          }
+        },
+        "error": {
+          "auth": "Login failed while checking the device cloud region. Confirm your credentials, then try again."
+        },
+        "abort": {
+          "entry_not_found": "The Blueair config entry no longer exists."
+        }
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {
-        "title": "Blue Air: Configuration",
+        "title": "Blueair: Configuration",
+        "description": "Adjust polling and region settings. Most users should keep the detected regions unless devices appear offline or stale.",
         "data": {
+          "region": "Account region",
+          "cloud_region": "Device cloud region",
           "scan_interval": "Polling Interval in Minutes"
         }
       }

--- a/custom_components/ha_blueair/translations/en.json
+++ b/custom_components/ha_blueair/translations/en.json
@@ -2,12 +2,25 @@
   "config": {
     "step": {
       "user": {
-        "title": "BlueAir Auth",
-        "description": "Configure your Credentials.",
+        "title": "Blueair Account",
+        "description": "Enter your Blueair account credentials.",
         "data": {
-          "region": "Region",
           "username": "Username",
           "password": "Password"
+        }
+      },
+      "account_region": {
+        "title": "Blueair Account Region",
+        "description": "More than one Blueair account region accepted these credentials. Choose the account region you normally use to sign in.",
+        "data": {
+          "region": "Account region"
+        }
+      },
+      "cloud_region": {
+        "title": "Blueair Device Cloud Region",
+        "description": "We could not choose a single device cloud region automatically. Suggested value: {suggested_cloud_region}. Source: {suggestion_source}. Choose the region for the device you want this entry to control. These options can be changed in the integration configuration.",
+        "data": {
+          "cloud_region": "Device cloud region"
         }
       },
       "reauth_confirm": {
@@ -19,11 +32,36 @@
       "auth": "Login failed. Please use official app to logout and log back in and try again."
     }
   },
+  "issues": {
+    "cloud_region_mismatch": {
+      "title": "Blueair device cloud region may be incorrect",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Confirm Blueair device cloud region",
+            "description": "The current device cloud region is {cloud_region}. Select the region to use for device control. The suggested value is {suggested_cloud_region}.",
+            "data": {
+              "cloud_region": "Device cloud region"
+            }
+          }
+        },
+        "error": {
+          "auth": "Login failed while checking the device cloud region. Confirm your credentials, then try again."
+        },
+        "abort": {
+          "entry_not_found": "The Blueair config entry no longer exists."
+        }
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {
-        "title": "Blue Air: Configuration",
+        "title": "Blueair: Configuration",
+        "description": "Adjust polling and region settings. Most users should keep the detected regions unless devices appear offline or stale.",
         "data": {
+          "region": "Account region",
+          "cloud_region": "Device cloud region",
           "scan_interval": "Polling Interval in Minutes"
         }
       }

--- a/custom_components/ha_blueair/translations/es.json
+++ b/custom_components/ha_blueair/translations/es.json
@@ -2,12 +2,25 @@
   "config": {
     "step": {
       "user": {
-        "title": "Autenticación a BlueAir",
-        "description": "Configure sus credenciales",
+        "title": "Cuenta de Blueair",
+        "description": "Introduce las credenciales de tu cuenta de Blueair.",
         "data": {
-          "region": "Región",
           "username": "Usuario",
           "password": "Contraseña"
+        }
+      },
+      "account_region": {
+        "title": "Región de la cuenta de Blueair",
+        "description": "Estas credenciales funcionan en más de una región de cuenta de Blueair. Elige la región que usas normalmente para iniciar sesión.",
+        "data": {
+          "region": "Región de la cuenta"
+        }
+      },
+      "cloud_region": {
+        "title": "Región de BlueCloud del dispositivo Blueair",
+        "description": "No se pudo elegir automáticamente una única región de BlueCloud para el dispositivo. Valor sugerido: {suggested_cloud_region}. Origen de la sugerencia: {suggestion_source}. Elige la región del dispositivo que quieres controlar con esta entrada. Puedes cambiar estas opciones en la configuración de la integración.",
+        "data": {
+          "cloud_region": "Región de BlueCloud del dispositivo"
         }
       },
       "reauth_confirm": {
@@ -17,6 +30,41 @@
     },
     "error": {
       "auth": "Error en inicio de sesión. Por favor cierre e inicie sesión en la aplicación oficial e intente de nuevo."
+    }
+  },
+  "issues": {
+    "cloud_region_mismatch": {
+      "title": "La región de BlueCloud del dispositivo Blueair puede ser incorrecta",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Confirmar la región de BlueCloud del dispositivo Blueair",
+            "description": "La región actual de BlueCloud es {cloud_region}. Elige la región que se usará para controlar el dispositivo. Valor sugerido: {suggested_cloud_region}.",
+            "data": {
+              "cloud_region": "Región de BlueCloud del dispositivo"
+            }
+          }
+        },
+        "error": {
+          "auth": "No se pudo iniciar sesión al comprobar la región de BlueCloud del dispositivo. Revisa tus credenciales e inténtalo de nuevo."
+        },
+        "abort": {
+          "entry_not_found": "La entrada de configuración de Blueair ya no existe."
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Blueair: configuración",
+        "description": "Ajusta el sondeo y las regiones. La mayoría de los usuarios deberían mantener las regiones detectadas salvo que los dispositivos aparezcan sin conexión o con datos desactualizados.",
+        "data": {
+          "region": "Región de la cuenta",
+          "cloud_region": "Región de BlueCloud del dispositivo",
+          "scan_interval": "Intervalo de sondeo en minutos"
+        }
+      }
     }
   }
 }

--- a/custom_components/ha_blueair/translations/fr.json
+++ b/custom_components/ha_blueair/translations/fr.json
@@ -2,12 +2,25 @@
   "config": {
     "step": {
       "user": {
-        "title": "Authentification BlueAir",
-        "description": "Connectez-vous",
+        "title": "Compte Blueair",
+        "description": "Saisissez les identifiants de votre compte Blueair.",
         "data": {
-          "region": "Région",
           "username": "Identifiant",
           "password": "Mot de passe"
+        }
+      },
+      "account_region": {
+        "title": "Région du compte Blueair",
+        "description": "Ces identifiants sont acceptés dans plusieurs régions de compte Blueair. Choisissez la région que vous utilisez habituellement pour vous connecter.",
+        "data": {
+          "region": "Région du compte"
+        }
+      },
+      "cloud_region": {
+        "title": "Région BlueCloud de l'appareil Blueair",
+        "description": "Impossible de choisir automatiquement une seule région BlueCloud pour l'appareil. Valeur suggérée : {suggested_cloud_region}. Source de la suggestion : {suggestion_source}. Choisissez la région de l'appareil que cette entrée doit contrôler. Ces options peuvent être modifiées dans la configuration de l'intégration.",
+        "data": {
+          "cloud_region": "Région BlueCloud de l'appareil"
         }
       },
       "reauth_confirm": {
@@ -17,6 +30,41 @@
     },
     "error": {
       "auth": "Échec de connexion. Veuillez utiliser l'application officielle pour vous déconnecter, puis reconnectez-vous et réessayez."
+    }
+  },
+  "issues": {
+    "cloud_region_mismatch": {
+      "title": "La région BlueCloud de l'appareil Blueair peut être incorrecte",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Confirmer la région BlueCloud de l'appareil Blueair",
+            "description": "La région BlueCloud actuelle est {cloud_region}. Choisissez la région à utiliser pour contrôler l'appareil. Valeur suggérée : {suggested_cloud_region}.",
+            "data": {
+              "cloud_region": "Région BlueCloud de l'appareil"
+            }
+          }
+        },
+        "error": {
+          "auth": "Échec de la connexion lors de la vérification de la région BlueCloud de l'appareil. Vérifiez vos identifiants, puis réessayez."
+        },
+        "abort": {
+          "entry_not_found": "L'entrée de configuration Blueair n'existe plus."
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Blueair : configuration",
+        "description": "Ajustez l'intervalle d'interrogation et les régions. La plupart des utilisateurs devraient conserver les régions détectées, sauf si les appareils apparaissent hors ligne ou avec des données obsolètes.",
+        "data": {
+          "region": "Région du compte",
+          "cloud_region": "Région BlueCloud de l'appareil",
+          "scan_interval": "Intervalle d'interrogation en minutes"
+        }
+      }
     }
   },
   "entity": {

--- a/custom_components/ha_blueair/translations/sv.json
+++ b/custom_components/ha_blueair/translations/sv.json
@@ -2,11 +2,25 @@
   "config": {
     "step": {
       "user": {
-        "title": "BlueAir Autensiering",
-        "description": "Konfigurera dina användaruppgifter.",
+        "title": "Blueair-konto",
+        "description": "Ange inloggningsuppgifterna för ditt Blueair-konto.",
         "data": {
           "username": "Användarnamn",
           "password": "Lösenord"
+        }
+      },
+      "account_region": {
+        "title": "Blueair-kontoregion",
+        "description": "De här inloggningsuppgifterna fungerar i mer än en Blueair-kontoregion. Välj den region du vanligtvis använder när du loggar in.",
+        "data": {
+          "region": "Kontoregion"
+        }
+      },
+      "cloud_region": {
+        "title": "Blueair-enhetens molnregion",
+        "description": "Det gick inte att automatiskt välja en enda BlueCloud-region för enheten. Föreslaget värde: {suggested_cloud_region}. Källa till förslaget: {suggestion_source}. Välj regionen för enheten som den här posten ska styra. Du kan ändra de här alternativen i integrationens konfiguration.",
+        "data": {
+          "cloud_region": "Enhetens molnregion"
         }
       },
       "reauth_confirm": {
@@ -16,6 +30,41 @@
     },
     "error": {
       "auth": "Inloggingen misslyckades. Använd den officiella appen för att logga ut och in samt försök igen."
+    }
+  },
+  "issues": {
+    "cloud_region_mismatch": {
+      "title": "Blueair-enhetens molnregion kan vara felaktig",
+      "fix_flow": {
+        "step": {
+          "init": {
+            "title": "Bekräfta Blueair-enhetens molnregion",
+            "description": "Den aktuella molnregionen är {cloud_region}. Välj den region som ska användas för att styra enheten. Föreslaget värde: {suggested_cloud_region}.",
+            "data": {
+              "cloud_region": "Enhetens molnregion"
+            }
+          }
+        },
+        "error": {
+          "auth": "Inloggningen misslyckades när enhetens molnregion kontrollerades. Kontrollera dina användaruppgifter och försök igen."
+        },
+        "abort": {
+          "entry_not_found": "Blueair-konfigurationsposten finns inte längre."
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Blueair: konfiguration",
+        "description": "Justera avsökning och regioninställningar. De flesta användare bör behålla de identifierade regionerna om inte enheter visas som offline eller har inaktuella värden.",
+        "data": {
+          "region": "Kontoregion",
+          "cloud_region": "Enhetens molnregion",
+          "scan_interval": "Avsökningsintervall i minuter"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds BlueCloud **device cloud region** selection to the config flow so accounts
whose Gigya login region differs from the region their hardware is actually
provisioned in (e.g. CP7i devices) can be controlled. Builds on the
region-discovery primitives shipped in `blueair-api==1.53.0`. Works toward #312.

Most accounts use the same region for login and device control and are unaffected —
discovery runs automatically and, when one online region is clear, setup completes
with no extra prompt.

## What changes

- **Config entry schema v3** with a silent `v2 -> v3` migration that seeds
  `cloud_region = region` for existing entries (no user action required).
- **Setup** now passes both `gigya_region=region` and `cloud_region=cloud_region`
  to the library; the MQTT broker uses `cloud_region`.
- **Config flow**: after credentials/account region, the integration probes the
  Blueair cloud for the likely device cloud region. If one online region is clear it
  saves automatically; if ambiguous, it adds a second step to pick the device cloud
  region.
- **Repair issue**: a frozen/empty AWS snapshot (detected via
  `device_state_looks_frozen()`) raises a repair the user can fix; the fix flow
  re-probes, lets the user confirm/update `cloud_region`, and reloads the entry.
- **Translations** for the new steps and repair (en, es, fr, sv).
- **README**: new "Account Region and Device Cloud Region" section describing the
  setup and repair flows.
- **manifest**: requirement bumped to `blueair-api==1.53.0` (region discovery).

## Compatibility

- Existing single-region users see **no behavior change** — migration backfills
  `cloud_region` from the saved `region`, and discovery short-circuits on the
  already-selected region.
- Discovery only runs on explicit setup/repair actions; it never mutates region
  state on a normal startup or refresh.

## Testing

- `ruff check custom_components/` clean.
- `py_compile` clean on changed modules.
- All translation/manifest JSON files validate.

## Rollout note

Per the #312 plan and the merged release-workflow change (#368), this is a good
candidate to publish as a `-beta` first so opt-in HACS testers can validate it on
real CP7i hardware before it ships stable.

## Rollout Plan — please cut a beta first (do not merge to `main` yet)

This PR is intentionally left as a **draft**. Per the #312 plan and the
pre-release workflow added in #368, this change should be validated on real CP7i
hardware and anyone else willing to try as a `-beta` before it ships to everyone. Merging straight to `main`
would trigger the normal push-to-main release and publish it as **stable to all
users**, skipping that field-test.

The beta can't be cut from my fork PR directly — `workflow_dispatch` only lists
branches that exist in `dahlb/ha_blueair`, and the Release workflow's "Push
changes" step writes the version-bump commit + tag back to the dispatched ref,
which it can't do on a fork branch. So, the branch needs to live in this repo
first.

### Suggested sequence

1. **Mirror this branch into `dahlb/ha_blueair` (without merging this PR):**

   ```bash
   gh pr checkout 372
   git push origin HEAD:feature/region-selection-ui
   ```

   (or, without `gh`:)

   ```bash
   git fetch https://github.com/philjn/ha_blueair feature/region-selection-ui
   git push origin FETCH_HEAD:feature/region-selection-ui
   ```

   This only copies the commit to a branch in your repo — it does **not** merge
   or close this PR.

2. **Cut the beta:** **Actions → Release → Run workflow** → select
   `feature/region-selection-ui` as the ref → set **Pre-release version** to
   `1.51.0-beta.1`. HACS then offers it only to users who enable
   **Show beta versions**.

3. **Testers validate** on real CP7i accounts/hardware (exact version string +
   diagnostics in any report).

4. **Ship stable:** once it checks out, mark this PR **ready** and **merge to
   `main`** → the usual push-to-main flow publishes the stable release.

### Note on versioning

`manifest.json`'s `version` is intentionally left at the upstream value
(`1.50.0`) in this PR — contributors don't bump it. The beta dispatch bumps it on
the upstream branch, and the eventual push-to-main handles the stable bump
automatically.
