### PR TITLE
Fix DH3i 2-in-1: humidifier on/off no longer powers down the purifier (#241)

### DIFF
--- a/custom_components/ha_blueair/blueair_update_coordinator_device_aws.py
+++ b/custom_components/ha_blueair/blueair_update_coordinator_device_aws.py
@@ -93,6 +93,15 @@ class BlueairUpdateCoordinatorDeviceAws(BlueairUpdateCoordinator):
         return self.blueair_api_device.auto_regulated_humidity
 
     @property
+    def hum_mode(self) -> bool | None | NotImplemented:
+        """Humidification on/off for 2-in-1 combo devices (e.g. DH3i).
+
+        Independent of the purifier running state (standby), so toggling
+        humidification does not power down the fan.
+        """
+        return self.blueair_api_device.hum_mode
+
+    @property
     def voc(self) -> int | None | NotImplemented:
         if self.blueair_api_device.total_voc is NotImplemented:
             return self.blueair_api_device.voc
@@ -283,6 +292,10 @@ class BlueairUpdateCoordinatorDeviceAws(BlueairUpdateCoordinator):
 
     async def set_auto_regulated_humidity(self, value) -> None:
         await self.blueair_api_device.set_auto_regulated_humidity(value)
+        await self.async_request_refresh()
+
+    async def set_hum_mode(self, value: bool) -> None:
+        await self.blueair_api_device.set_hum_mode(value)
         await self.async_request_refresh()
 
     async def set_main_mode(self, value: int) -> None:

--- a/custom_components/ha_blueair/blueair_update_coordinator_device_aws.py
+++ b/custom_components/ha_blueair/blueair_update_coordinator_device_aws.py
@@ -93,13 +93,13 @@ class BlueairUpdateCoordinatorDeviceAws(BlueairUpdateCoordinator):
         return self.blueair_api_device.auto_regulated_humidity
 
     @property
-    def hum_mode(self) -> bool | None | NotImplemented:
+    def humidifier_mode(self) -> bool | None | NotImplemented:
         """Humidification on/off for 2-in-1 combo devices (e.g. DH3i).
 
         Independent of the purifier running state (standby), so toggling
         humidification does not power down the fan.
         """
-        return self.blueair_api_device.hum_mode
+        return self.blueair_api_device.humidifier_mode
 
     @property
     def voc(self) -> int | None | NotImplemented:
@@ -294,8 +294,8 @@ class BlueairUpdateCoordinatorDeviceAws(BlueairUpdateCoordinator):
         await self.blueair_api_device.set_auto_regulated_humidity(value)
         await self.async_request_refresh()
 
-    async def set_hum_mode(self, value: bool) -> None:
-        await self.blueair_api_device.set_hum_mode(value)
+    async def set_humidifier_mode(self, value: bool) -> None:
+        await self.blueair_api_device.set_humidifier_mode(value)
         await self.async_request_refresh()
 
     async def set_main_mode(self, value: int) -> None:

--- a/custom_components/ha_blueair/humidifier.py
+++ b/custom_components/ha_blueair/humidifier.py
@@ -42,11 +42,11 @@ class BlueairAwsHumidifier(BlueairEntity, HumidifierEntity):
     @classmethod
     def is_implemented(kls, coordinator):
         # Standalone humidifiers only. 2-in-1 combo devices (which expose a
-        # dedicated ``hum_mode``) are handled by BlueairAwsComboHumidifier so
+        # dedicated ``humidifier_mode``) are handled by BlueairAwsComboHumidifier so
         # that turning humidification off does not power down the purifier.
         return (
             coordinator.auto_regulated_humidity is not NotImplemented
-            and coordinator.hum_mode is NotImplemented
+            and coordinator.humidifier_mode is NotImplemented
         )
 
     def __init__(self, coordinator: BlueairUpdateCoordinator):
@@ -129,7 +129,7 @@ class BlueairAwsComboHumidifier(BlueairEntity, HumidifierEntity):
     """Controls humidification on a 2-in-1 Purify+Humidify device (e.g. DH3i).
 
     On these devices humidification is a sub-function of the purifier, toggled
-    via ``hum_mode`` independently of the device's master power (``standby``).
+    via ``humidifier_mode`` independently of the device's master power (``standby``).
     Powering the purifier on/off and selecting its operating mode is handled by
     the fan entity, so this entity intentionally exposes only humidification
     on/off plus the target humidity (no modes).
@@ -137,7 +137,7 @@ class BlueairAwsComboHumidifier(BlueairEntity, HumidifierEntity):
 
     @classmethod
     def is_implemented(kls, coordinator):
-        return coordinator.hum_mode is not NotImplemented
+        return coordinator.humidifier_mode is not NotImplemented
 
     def __init__(self, coordinator: BlueairUpdateCoordinator):
         """Initialize the combo humidifier."""
@@ -147,7 +147,7 @@ class BlueairAwsComboHumidifier(BlueairEntity, HumidifierEntity):
 
     @property
     def is_on(self) -> bool | None:
-        return self.coordinator.hum_mode
+        return self.coordinator.humidifier_mode
 
     @property
     def target_humidity(self):
@@ -158,7 +158,7 @@ class BlueairAwsComboHumidifier(BlueairEntity, HumidifierEntity):
         return self.coordinator.humidity
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        await self.coordinator.set_hum_mode(False)
+        await self.coordinator.set_humidifier_mode(False)
         self.async_write_ha_state()
 
     async def async_turn_on(
@@ -167,7 +167,7 @@ class BlueairAwsComboHumidifier(BlueairEntity, HumidifierEntity):
         preset_mode: str | None = None,
         **kwargs: Any,
     ) -> None:
-        await self.coordinator.set_hum_mode(True)
+        await self.coordinator.set_humidifier_mode(True)
         self.async_write_ha_state()
 
     async def async_set_humidity(self, humidity):

--- a/custom_components/ha_blueair/humidifier.py
+++ b/custom_components/ha_blueair/humidifier.py
@@ -31,16 +31,23 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         async_add_entities,
         entity_classes=[
             BlueairAwsHumidifier,
+            BlueairAwsComboHumidifier,
         ],
     )
 
 
 class BlueairAwsHumidifier(BlueairEntity, HumidifierEntity):
-    """Controls Humidifier."""
+    """Controls a standalone humidifier (master power toggles the device)."""
 
     @classmethod
     def is_implemented(kls, coordinator):
-        return coordinator.auto_regulated_humidity is not NotImplemented
+        # Standalone humidifiers only. 2-in-1 combo devices (which expose a
+        # dedicated ``hum_mode``) are handled by BlueairAwsComboHumidifier so
+        # that turning humidification off does not power down the purifier.
+        return (
+            coordinator.auto_regulated_humidity is not NotImplemented
+            and coordinator.hum_mode is NotImplemented
+        )
 
     def __init__(self, coordinator: BlueairUpdateCoordinator):
         """Initialize the humidifier."""
@@ -115,4 +122,55 @@ class BlueairAwsHumidifier(BlueairEntity, HumidifierEntity):
         """Set the humidity level. Sets Humidifier to 'On' to comply with hass requirements, and sets mode to Auto since this is the only mode in which the target humidity is used."""
         await self.coordinator.set_auto_regulated_humidity(humidity)
         await self.coordinator.set_fan_auto_mode(True)
+        await self.async_turn_on()
+
+
+class BlueairAwsComboHumidifier(BlueairEntity, HumidifierEntity):
+    """Controls humidification on a 2-in-1 Purify+Humidify device (e.g. DH3i).
+
+    On these devices humidification is a sub-function of the purifier, toggled
+    via ``hum_mode`` independently of the device's master power (``standby``).
+    Powering the purifier on/off and selecting its operating mode is handled by
+    the fan entity, so this entity intentionally exposes only humidification
+    on/off plus the target humidity (no modes).
+    """
+
+    @classmethod
+    def is_implemented(kls, coordinator):
+        return coordinator.hum_mode is not NotImplemented
+
+    def __init__(self, coordinator: BlueairUpdateCoordinator):
+        """Initialize the combo humidifier."""
+        self._attr_device_class = HumidifierDeviceClass.HUMIDIFIER
+        self._attr_supported_features = HumidifierEntityFeature(0)
+        super().__init__("Humidifier", coordinator)
+
+    @property
+    def is_on(self) -> bool | None:
+        return self.coordinator.hum_mode
+
+    @property
+    def target_humidity(self):
+        return self.coordinator.auto_regulated_humidity
+
+    @property
+    def current_humidity(self):
+        return self.coordinator.humidity
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self.coordinator.set_hum_mode(False)
+        self.async_write_ha_state()
+
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        await self.coordinator.set_hum_mode(True)
+        self.async_write_ha_state()
+
+    async def async_set_humidity(self, humidity):
+        """Set the target humidity and ensure humidification is on."""
+        await self.coordinator.set_auto_regulated_humidity(humidity)
         await self.async_turn_on()

--- a/custom_components/ha_blueair/manifest.json
+++ b/custom_components/ha_blueair/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dahlb/ha_blueair/issues",
   "loggers": ["ha_blueair", "blueair_api"],
-  "requirements": ["blueair-api @ git+https://github.com/philjn/blueair_api.git@feature/dh3i-combo-support"],
+  "requirements": ["blueair-api==1.54.0"],
   "version": "1.50.0"
 }

--- a/custom_components/ha_blueair/manifest.json
+++ b/custom_components/ha_blueair/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dahlb/ha_blueair/issues",
   "loggers": ["ha_blueair", "blueair_api"],
-  "requirements": ["blueair-api==1.52.0"],
+  "requirements": ["blueair-api @ git+https://github.com/philjn/blueair_api.git@feature/dh3i-combo-support"],
   "version": "1.50.0"
 }


### PR DESCRIPTION
Fixes #241, 

Special thanks to [rgaiser](https://github.com/rgaiser) for providing the detailed logs.

## Problem

On the 2-in-1 Purify + Humidify combo (DH3i, hardware `s_cmb2in1`) the
humidifier entity drove the device's `standby` field for on/off. Turning the
humidifier **off** therefore powered down the **entire unit**, stopping air
purification. On this device humidification is an independent sub-function — it
should be possible to stop humidifying while the purifier keeps running.

## Fix

The combo exposes a dedicated humidification toggle (`humidifier_mode`, backed by the
`hummode` device field) that is separate from whole-device power. This PR adds a
combo-specific humidifier entity that uses it, and reverts the standalone
humidifier to its original behavior. The two entities are gated to be mutually
exclusive, so each device gets exactly one humidifier.

`humidifier.py` now registers two entity classes:

- **`BlueairAwsHumidifier`** (standalone humidifiers) — reverted to the original
  `standby`-based on/off plus the Auto / Sleep / Fan-speed modes. Gate now
  **excludes** combos:
  `auto_regulated_humidity is not NotImplemented and humidifier_mode is NotImplemented`.
- **`BlueairAwsComboHumidifier`** (NEW, combo units) — gate
  `humidifier_mode is not NotImplemented`. `supported_features = HumidifierEntityFeature(0)`
  (no modes — operating mode belongs on the fan entity for these devices).
  - on/off → `set_humidifier_mode(True/False)`
  - target humidity → `set_auto_regulated_humidity` (+ turn on)
  - current humidity → `humidity`

The purifier's power and operating mode remain on the **fan** entity, so the
combo shows up in Home Assistant as a Fan (purifier) plus a Humidifier
(humidify) that can be toggled independently.

Coordinator (`blueair_update_coordinator_device_aws.py`) gains a `humidifier_mode`
property and a `set_humidifier_mode(bool)` setter that calls the library and requests a
refresh.

The combo's field names were determined from investigation of the Blueair cloud
API responses and AWS IoT shadow protocol behavior for this device.

## Library dependency

Uses the `humidifier_mode` attribute added in `blueair-api` (dahlb/blueair_api#139,
released as **v1.54.0** on PyPI). `manifest.json` is pinned to `blueair-api==1.54.0`.

## Scope

- Humidification on/off and target humidity now; operating-mode/fan presets for
  the combo are a deferred follow-up.
- Fan presets for the combo (via the unit's mode selector) and the
  `fan_speed_count` value for `s_cmb2in1` are not in this PR — they need a
  confirmed fan-speed range from a real device.

## Testing

- `ruff check` on the changed files → clean
- `py_compile` on the changed files → clean
- Gate verification against the captured DH3i state: combo humidifier entity is
  created, standalone humidifier is excluded.
