### PR TITLE
Add Overall Firmware diagnostic sensor (AWS)

### DIFF
--- a/custom_components/ha_blueair/blueair_update_coordinator_device_aws.py
+++ b/custom_components/ha_blueair/blueair_update_coordinator_device_aws.py
@@ -34,6 +34,16 @@ class BlueairUpdateCoordinatorDeviceAws(BlueairUpdateCoordinator):
         return self.blueair_api_device.firmware
 
     @property
+    def overall_firmware(self) -> str | None | NotImplemented:
+        """Overall firmware version (AWS shadow field ``ofv``).
+
+        Distinct from ``sw_version`` (Wi-Fi firmware) and ``hw_version``
+        (MCU firmware); surfaced as a diagnostic sensor since the device
+        registry only has the two version slots.
+        """
+        return self.blueair_api_device.overall_firmware
+
+    @property
     def serial_number(self) -> str:
         return self.blueair_api_device.serial_number
 

--- a/custom_components/ha_blueair/manifest.json
+++ b/custom_components/ha_blueair/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dahlb/ha_blueair/issues",
   "loggers": ["ha_blueair", "blueair_api"],
-  "requirements": ["blueair-api==1.54.0"],
+  "requirements": ["blueair-api==1.56.0"],
   "version": "1.51.0"
 }

--- a/custom_components/ha_blueair/sensor.py
+++ b/custom_components/ha_blueair/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
     CONCENTRATION_PARTS_PER_BILLION,
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    EntityCategory,
 )
 
 from .blueair_update_coordinator import BlueairUpdateCoordinator
@@ -35,6 +36,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             BlueairWaterLevelSensor,
             BlueairRssiSensor,
             BlueairTimerDurationSensor,
+            BlueairOverallFirmwareSensor,
     ])
 
 
@@ -244,3 +246,36 @@ class BlueairTimerDurationSensor(BlueairSensor):
         if not isinstance(coordinator, BlueairUpdateCoordinatorDeviceAws):
             return False
         return super().is_implemented(coordinator)
+
+
+class BlueairOverallFirmwareSensor(BlueairSensor):
+    """Reports the device's overall firmware version (AWS shadow ``ofv``).
+
+    The device registry only exposes two version slots, already used for
+    Wi-Fi firmware (``sw_version``) and MCU firmware (``hw_version``), so
+    the overall firmware version is surfaced here as a diagnostic sensor.
+    AWS-only and disabled by default to avoid cluttering the device page;
+    the value updates live over MQTT.  This is a text value, so it carries
+    no device class, unit, or state class.
+    """
+    entity_description = SensorEntityDescription(
+        key="overall_firmware",
+        name="Overall Firmware",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        icon="mdi:chip",
+    )
+
+    @classmethod
+    def is_implemented(kls, coordinator):
+        # AWS-only entity: the legacy Device class has no overall firmware
+        # attribute.  Guard explicitly (mirrors the other AWS-only sensors)
+        # so it is never offered for a legacy coordinator (issue #356).
+        if not isinstance(coordinator, BlueairUpdateCoordinatorDeviceAws):
+            return False
+        return super().is_implemented(coordinator)
+
+    @property
+    def state_class(self):
+        """Firmware version is a text value with no state class."""
+        return None


### PR DESCRIPTION
# Add Overall Firmware diagnostic sensor (AWS)

Companion to dahlb/blueair_api#142 (firmware-version shadow fields), released in
blueair-api v1.56.0.

## Background

The blueair_api library now exposes a third firmware version on AWS devices:

| Library attr | Source | Surfaced in HA as |
|---|---|---|
| `firmware` (cfv) | Wi‑Fi firmware | `DeviceInfo.sw_version` (device card) |
| `mcu_firmware` (mfv) | MCU firmware | `DeviceInfo.hw_version` (device card) |
| `overall_firmware` (ofv) | Overall firmware | **(nothing — no slot)** |

`DeviceInfo` only has the two version slots and both are taken, so the overall
firmware version has no home on the device card.

## Change

- Add an `overall_firmware` property to the AWS update coordinator.
- Add `BlueairOverallFirmwareSensor` — an AWS-only diagnostic sensor
  (`EntityCategory.DIAGNOSTIC`, disabled by default) that reports the overall
  firmware version. It is a text value, so it carries no device class, unit, or
  state class.
- The sensor follows the existing AWS-only pattern (`is_implemented` guards on
  `BlueairUpdateCoordinatorDeviceAws`), so it is never offered to legacy
  coordinators (issue #356-safe) and auto-hides on devices that don't report it.
- The value updates live over MQTT thanks to the companion library change.

## Requirements

- Bumps the `blueair-api` requirement to `==1.56.0`, which is the release that
  introduced `overall_firmware` (dahlb/blueair_api#142).

## Validation

- `ruff` clean; `py_compile` clean; manifest JSON valid.
- Diff is 3 files: `sensor.py`, `blueair_update_coordinator_device_aws.py`,
  `manifest.json`.
