### PR TITLE
feat: Add Night Light entity for Mini Restful (perimeter ring)

### DIFF
--- a/custom_components/ha_blueair/blueair_update_coordinator.py
+++ b/custom_components/ha_blueair/blueair_update_coordinator.py
@@ -313,6 +313,14 @@ class BlueairUpdateCoordinator(ABC, DataUpdateCoordinator):
         pass
 
     @abstractmethod
+    async def set_night_light_brightness(self, night_light_brightness: int) -> None:
+        pass
+
+    @abstractmethod
+    async def turn_off_night_light_brightness(self) -> None:
+        pass
+
+    @abstractmethod
     async def set_wick_dry_mode(self, value) -> None:
         pass
 

--- a/custom_components/ha_blueair/blueair_update_coordinator_device.py
+++ b/custom_components/ha_blueair/blueair_update_coordinator_device.py
@@ -215,6 +215,12 @@ class BlueairUpdateCoordinatorDevice(BlueairUpdateCoordinator):
     async def turn_off_mood_brightness(self) -> None:
         raise NotImplementedError
 
+    async def set_night_light_brightness(self, night_light_brightness: int) -> None:
+        raise NotImplementedError
+
+    async def turn_off_night_light_brightness(self) -> None:
+        raise NotImplementedError
+
     async def set_germ_shield(self, enabled: bool) -> None:
         raise NotImplementedError
 

--- a/custom_components/ha_blueair/blueair_update_coordinator_device_aws.py
+++ b/custom_components/ha_blueair/blueair_update_coordinator_device_aws.py
@@ -258,8 +258,21 @@ class BlueairUpdateCoordinatorDeviceAws(BlueairUpdateCoordinator):
         return self.blueair_api_device.rssi
 
     @property
+    def night_light_brightness_scale(self) -> tuple[int, int]:
+        return (1, 100)
+
+    @property
     def night_light_brightness(self) -> int | None | NotImplemented:
+        if self.blueair_api_device.night_light_brightness not in (None, NotImplemented):
+            return value_to_brightness(
+                self.night_light_brightness_scale,
+                self.blueair_api_device.night_light_brightness,
+            )
         return self.blueair_api_device.night_light_brightness
+
+    @property
+    def night_light_brightness_is_on(self) -> bool | None | NotImplemented:
+        return self.blueair_api_device.night_light_brightness != 0
 
     @property
     def timer_state(self) -> int | None | NotImplemented:
@@ -360,8 +373,15 @@ class BlueairUpdateCoordinatorDeviceAws(BlueairUpdateCoordinator):
         await self.blueair_api_device.set_fan_speed_0(value)
         await self.async_request_refresh()
 
-    async def set_night_light_brightness(self, value: int) -> None:
-        await self.blueair_api_device.set_night_light_brightness(value)
+    async def set_night_light_brightness(self, night_light_brightness) -> None:
+        desired_brightness_in_range = ceil(
+            brightness_to_value(self.night_light_brightness_scale, night_light_brightness)
+        )
+        await self.blueair_api_device.set_night_light_brightness(desired_brightness_in_range)
+        await self.async_request_refresh()
+
+    async def turn_off_night_light_brightness(self) -> None:
+        await self.blueair_api_device.set_night_light_brightness(0)
         await self.async_request_refresh()
 
     async def set_timer_duration(self, value: int) -> None:

--- a/custom_components/ha_blueair/light.py
+++ b/custom_components/ha_blueair/light.py
@@ -19,6 +19,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         entity_classes=[
             BlueairLightEntity,
             BlueairMoodLightEntity,
+            BlueairNightLightEntity,
     ])
 
 
@@ -80,4 +81,35 @@ class BlueairMoodLightEntity(BlueairEntity, LightEntity):
 
     async def async_turn_off(self, **kwargs):
         await self.coordinator.turn_off_mood_brightness()
+        self.async_write_ha_state()
+
+
+class BlueairNightLightEntity(BlueairEntity, LightEntity):
+    _attr_color_mode = ColorMode.BRIGHTNESS
+    _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+
+    @classmethod
+    def is_implemented(kls, coordinator):
+        return coordinator.night_light_brightness is not NotImplemented
+
+    def __init__(self, coordinator):
+        super().__init__("Night Light", coordinator)
+
+    @property
+    def brightness(self) -> int | None:
+        """Return the brightness of this light between 0..255."""
+        return self.coordinator.night_light_brightness
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the entity is on."""
+        return self.coordinator.night_light_brightness_is_on
+
+    async def async_turn_on(self, **kwargs):
+        desired_brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
+        await self.coordinator.set_night_light_brightness(desired_brightness)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs):
+        await self.coordinator.turn_off_night_light_brightness()
         self.async_write_ha_state()


### PR DESCRIPTION
Closes part of #322

## Summary

Adds a **Night Light** entity that controls the Mini Restful's illuminated
perimeter ring (the `nlstepless` datapoint). This is the "upper perimeter ring"
light requested in #322 — distinct from the existing **LED Light** entity, which
controls the device's display screen (`ledb`).

The Blueair Android app itself labels this control **"Night light"**. The entity name mirrors the app's own verbiage.

> Note: The Sunrise alarm feature also mentioned in #322 is intentionally **out
> of scope** for this PR and will be addressed separately.

## Changes

- **`blueair_update_coordinator.py`** — add abstract `set_night_light_brightness`
  and `turn_off_night_light_brightness` to the coordinator interface.
- **`blueair_update_coordinator_device_aws.py`** — implement night-light support
  for AWS/cloud-push devices:
  - `night_light_brightness_scale` = `(1, 100)`
  - scaled `night_light_brightness` getter (`value_to_brightness`)
  - `night_light_brightness_is_on`
  - `set_night_light_brightness` (`ceil(brightness_to_value(...))`) and
    `turn_off_night_light_brightness` (writes `0`)
  - Mirrors the existing `mood_brightness` pattern exactly.
- **`blueair_update_coordinator_device.py`** — add `NotImplementedError` stubs for
  legacy (non-AWS) devices.
- **`light.py`** — add `BlueairNightLightEntity` ("Night Light"), gated on
  `night_light_brightness is not NotImplemented`, and register it in
  `async_setup_entry`.

## How it maps

| App control | Datapoint | HA entity |
|-------------|-----------|-----------|
| "Night light" (perimeter ring) | `nlstepless` (0–100) | **Night Light** (new) |
| Display screen | `ledb` / `brightness` | LED Light (existing) |

## Testing

- `ruff check` — clean on all four edited files.
- The `blueair-api` library already covers the underlying mapping/setter
  (`test_set_night_light_brightness`, brightness scaling `== 75`, Mini Restful
  fixture `night_light_brightness == 0`); full library suite: **182 passed**.
- ha_blueair has no tracked test harness, so no HA-side tests were added
  (consistent with the existing Mood/LED light entities).