### PR TITLE
feat: Stop Filter/Wick/Water sensors from reporting as batteries

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,44 @@ A custom integration for Blueair Filters.  If your model isn't reported correctl
 ## Installation ##
 You can install this either manually copying files or using HACS. Configuration can be done on UI, you need to enter your username and password, (I know, translations are missing).
 
+## Filter, Wick and Water sensors no longer report as batteries ##
+
+The **Filter Life**, **Wick Life**, **Water Refresher Life** and **Water Level**
+sensors used to be created with Home Assistant's `battery` device class. Because
+they report a percentage, that classification pulled them into battery
+dashboards, battery groups, low-battery notification automations/blueprints, and
+HomeKit / voice-assistant battery reporting — even though none of them is a
+battery.
+
+These are filter/wick/refresher remaining-life and water-level percentages, so
+the `battery` device class has been removed. There is no Home Assistant device
+class that fits "filter life" or "water level", so they now have no device class.
+The state values, `%` unit, `measurement` state class, icons and long-term
+history are unchanged — only the battery classification is gone.
+
+If you deliberately relied on the battery classification (for example a battery
+dashboard that lists these sensors), you can re-create it with a
+[template sensor](https://www.home-assistant.io/integrations/template/). Home
+Assistant does not let you override a natively-set device class from the UI, so a
+template sensor is the supported way to keep a battery-classified copy:
+
+```yaml
+# configuration.yaml
+template:
+  - sensor:
+      - name: "Bedroom Blueair Filter Battery"
+        unique_id: bedroom_blueair_filter_battery
+        device_class: battery
+        unit_of_measurement: "%"
+        state_class: measurement
+        # Replace with your own entity id from Developer Tools > States
+        state: "{{ states('sensor.bedroom_blueair_filter_life') }}"
+        availability: "{{ has_value('sensor.bedroom_blueair_filter_life') }}"
+```
+
+After a restart the new `sensor.bedroom_blueair_filter_battery` behaves like a
+battery again, while the original sensor stays correctly unclassified.
+
 ## Beta / Pre-release Builds ##
 
 Some changes are easier to validate with a small group of opt-in testers before

--- a/custom_components/ha_blueair/sensor.py
+++ b/custom_components/ha_blueair/sensor.py
@@ -15,9 +15,23 @@ from homeassistant.const import (
     EntityCategory,
 )
 
+import homeassistant.helpers.issue_registry as ir
+
+from .const import DOMAIN, DATA_DEVICES, DATA_AWS_DEVICES
 from .blueair_update_coordinator import BlueairUpdateCoordinator
 from .blueair_update_coordinator_device_aws import BlueairUpdateCoordinatorDeviceAws
 from .entity import BlueairEntity, async_setup_entry_helper
+
+# Percentage sensors that used to (incorrectly) report device_class=battery.
+# See dahlb/ha_blueair#378.
+_LIFE_LEVEL_SENSOR_KEYS = (
+    "filter_life",
+    "wick_life",
+    "water_refresher_life",
+    "water_level",
+)
+BATTERY_DEVICE_CLASS_ISSUE_ID = "life_sensors_no_longer_battery"
+
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Blueair sensors from config entry."""
@@ -38,6 +52,34 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             BlueairTimerDurationSensor,
             BlueairOverallFirmwareSensor,
     ])
+
+    # The filter/wick/water-refresher life and water-level sensors previously
+    # used device_class=battery, so existing installs swept them into battery
+    # dashboards, low-battery automations and HomeKit battery reporting.  That
+    # classification has been removed (#378).  Surface a dismissible repair to
+    # let affected users know and point them at the migration guide.  Only fire
+    # when the account actually exposes one of these sensors, and self-heal if
+    # it no longer does.
+    coordinators = (
+        hass.data[DOMAIN][DATA_DEVICES] + hass.data[DOMAIN][DATA_AWS_DEVICES]
+    )
+    has_life_level_sensor = any(
+        getattr(coordinator, key, NotImplemented) is not NotImplemented
+        for coordinator in coordinators
+        for key in _LIFE_LEVEL_SENSOR_KEYS
+    )
+    if has_life_level_sensor:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            BATTERY_DEVICE_CLASS_ISSUE_ID,
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=BATTERY_DEVICE_CLASS_ISSUE_ID,
+            learn_more_url="https://github.com/dahlb/ha_blueair#filter-wick-and-water-sensors-no-longer-report-as-batteries",
+        )
+    else:
+        ir.async_delete_issue(hass, DOMAIN, BATTERY_DEVICE_CLASS_ISSUE_ID)
 
 
 class BlueairSensor(BlueairEntity, SensorEntity):
@@ -151,7 +193,6 @@ class BlueairFilterLifeSensor(BlueairSensor):
     entity_description = SensorEntityDescription(
         key="filter_life",
         name="Filter Life",
-        device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
         suggested_display_precision=0,
         icon="mdi:air-filter",
@@ -163,7 +204,6 @@ class BlueairWickLifeSensor(BlueairSensor):
     entity_description = SensorEntityDescription(
         key="wick_life",
         name="Wick Life",
-        device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
         suggested_display_precision=0,
         icon="mdi:air-filter",
@@ -174,7 +214,6 @@ class BlueairWaterRefresherLifeSensor(BlueairSensor):
     entity_description = SensorEntityDescription(
         key="water_refresher_life",
         name="Water Refresher Life",
-        device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
         suggested_display_precision=0,
         icon="mdi:air-filter",
@@ -185,7 +224,6 @@ class BlueairWaterLevelSensor(BlueairSensor):
     entity_description = SensorEntityDescription(
         key="water_level",
         name="Water Level",
-        device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
         suggested_display_precision=0,
         icon="mdi:waves",

--- a/custom_components/ha_blueair/strings.json
+++ b/custom_components/ha_blueair/strings.json
@@ -55,5 +55,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "life_sensors_no_longer_battery": {
+      "title": "Filter, Wick and Water sensors no longer report as batteries",
+      "description": "The Filter Life, Wick Life, Water Refresher Life and Water Level sensors previously used the `battery` device class, which incorrectly pulled them into battery dashboards, low-battery automations and HomeKit battery reporting. They are percentages, not batteries, so the `battery` device class has been removed. The values, units and history are unchanged.\n\nIf you relied on the old battery classification, follow the migration guide (Learn more) to re-create it with a template sensor. Otherwise you can safely dismiss this notice."
+    }
   }
 }

--- a/custom_components/ha_blueair/translations/en.json
+++ b/custom_components/ha_blueair/translations/en.json
@@ -55,5 +55,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "life_sensors_no_longer_battery": {
+      "title": "Filter, Wick and Water sensors no longer report as batteries",
+      "description": "The Filter Life, Wick Life, Water Refresher Life and Water Level sensors previously used the `battery` device class, which incorrectly pulled them into battery dashboards, low-battery automations and HomeKit battery reporting. They are percentages, not batteries, so the `battery` device class has been removed. The values, units and history are unchanged.\n\nIf you relied on the old battery classification, follow the migration guide (Learn more) to re-create it with a template sensor. Otherwise you can safely dismiss this notice."
+    }
   }
 }


### PR DESCRIPTION
Fixes #378

## Summary

The **Filter Life**, **Wick Life**, **Water Refresher Life** and **Water Level**
sensors were created with `device_class=SensorDeviceClass.BATTERY`. They report a
percentage, but they are filter/wick/refresher remaining-life and water-level
values — not batteries. That classification caused real problems for users:

- They were swept into battery dashboards, battery groups, and any
  `auto-entities` / template card filtering on `device_class: battery`.
- They triggered low-battery notification automations and the common low-battery
  blueprints when the percentage dropped.
- They were exposed to HomeKit and voice assistants as battery levels.

This PR removes the incorrect `battery` device class. Home Assistant has no
device class that fits "filter/wick/refresher life" or "water level", so leaving
it unset is correct. The values, `%` unit, `measurement` state class, icons and
long-term history are all unchanged — the sensors simply stop being classified as
batteries.

## Breaking change & migration

This is a (small) breaking change for anyone who deliberately relied on the
battery classification. To surface it the Home-Assistant-native way, this PR
raises a **dismissible Repairs issue** (warning severity, `is_fixable=False`) that
links to a new README section. The issue is only created when the account
actually exposes one of these four sensors, and it self-heals
(`async_delete_issue`) if it no longer does.

The README section documents a **template sensor** users can add to re-create a
battery-classified copy, since HA does not allow overriding a natively-set device
class from the UI. Users who don't care can just dismiss the notice.

## Changes

- **`sensor.py`** — remove `device_class=SensorDeviceClass.BATTERY` from
  `BlueairFilterLifeSensor`, `BlueairWickLifeSensor`,
  `BlueairWaterRefresherLifeSensor`, `BlueairWaterLevelSensor`; add a
  presence-gated, self-healing Repairs issue in `async_setup_entry`.
- **`strings.json`** / **`translations/en.json`** — add the
  `issues.life_sensors_no_longer_battery` title/description.
- **`README.md`** — add "Filter, Wick and Water sensors no longer report as
  batteries" section with a copy-paste template-sensor migration snippet (the
  Repairs `learn_more_url` target).

No `manifest.json` version bump (leaving the release/version bump to the
maintainer's workflow).

## Testing

- `ruff check custom_components/ha_blueair/sensor.py` — clean.
- `python -m py_compile custom_components/ha_blueair/sensor.py` — clean.
- `strings.json` and `translations/en.json` validated as JSON.

## Reviewer notes

- The Repairs issue reuses the same `getattr(coordinator, key, NotImplemented)
  is not NotImplemented` capability check the sensor platform already uses, so it
  only fires for devices that expose one of the four sensors.
- The `learn_more_url` anchor
  (`#filter-wick-and-water-sensors-no-longer-report-as-batteries`) matches the new
  README header slug.
