### PR TITLE
fix: tolerate legacy API outages instead of failing setup

### DIFF
--- a/custom_components/ha_blueair/__init__.py
+++ b/custom_components/ha_blueair/__init__.py
@@ -87,7 +87,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         except LoginError as ex:
             _LOGGER.debug(f"Legacy Login error: {ex}")
             devices = []
-        except Exception as ex:
+        except (ClientError, TimeoutError) as ex:
             _LOGGER.warning(f"Legacy Blueair API unavailable, skipping legacy devices: {ex}")
             devices = []
         aws_http_client, aws_devices = await get_aws_devices(

--- a/custom_components/ha_blueair/__init__.py
+++ b/custom_components/ha_blueair/__init__.py
@@ -3,6 +3,8 @@ from datetime import timedelta
 
 import voluptuous as vol
 
+from aiohttp import ClientError
+
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.const import (
@@ -84,6 +86,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
             )
         except LoginError as ex:
             _LOGGER.debug(f"Legacy Login error: {ex}")
+            devices = []
+        except Exception as ex:
+            _LOGGER.warning(f"Legacy Blueair API unavailable, skipping legacy devices: {ex}")
             devices = []
         aws_http_client, aws_devices = await get_aws_devices(
             username=username,
@@ -239,6 +244,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     except LoginError as error:
         _LOGGER.debug("login failure, ha should retry")
         raise ConfigEntryNotReady("Login failure") from error
+    except (ClientError, TimeoutError) as error:
+        _LOGGER.debug("blueair cloud unreachable, ha should retry")
+        raise ConfigEntryNotReady("Blueair cloud unreachable") from error
 
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):


### PR DESCRIPTION
## Problem

When the legacy `api.blueair.io` cloud is down, `async_setup_entry` fails entirely — even for accounts whose devices are all on the AWS API and don't use the legacy API at all.

During the Blueair legacy-API outage on 2026-07-16 (`/v2/user/<email>/homehost/` returning 503/504 with empty bodies, later timing out), setup crashed with:

```
aiohttp.client_exceptions.InvalidUrlClientError: https:///v2/user/<email>/login/
```

`blueair_api`'s `_get_home_host` only handles 404, so an empty 5xx body becomes an empty hostname and the login URL is malformed. The existing `except LoginError` around the legacy `get_devices()` call doesn't catch this, so the exception escapes, the entry lands in `setup_error`, and HA never retries — AWS devices stay unavailable until a manual reload succeeds.

## Fix

Two small changes in `async_setup_entry`:

1. Catch any exception from the legacy `get_devices()` call, log a warning, and continue with `devices = []` — a legacy-cloud outage shouldn't take down AWS-only accounts (and mixed accounts still get their AWS devices).
2. Catch `ClientError`/`TimeoutError` at the outer level and raise `ConfigEntryNotReady`, so genuine cloud unreachability (including the AWS side) gets HA's automatic retry-with-backoff instead of a hard `setup_error`.

## Validation

Tested live during the outage on a real setup (Blue Pure 211i Max + 2-in-1 Pro, both AWS devices): unpatched setup crashed with the traceback above on every reload attempt; with this patch both devices set up and came online while the legacy homehost endpoint was still unreachable.