### PR TITLE
feat: preserve light brightness

### DIFF
--- a/custom_components/ha_blueair/light.py
+++ b/custom_components/ha_blueair/light.py
@@ -39,13 +39,17 @@ class BlueairRestoredBrightnessEntity(BlueairEntity, LightEntity, RestoreEntity)
         """Restore the previous brightness after a Home Assistant restart."""
         await super().async_added_to_hass()
         last_state = await self.async_get_last_state()
-        if last_state is None or self.is_on:
+        if self.is_on:
             return
 
-        last_brightness = last_state.attributes.get(_ATTR_LAST_BRIGHTNESS)
-        if isinstance(last_brightness, int) and not isinstance(last_brightness, bool):
-            if 0 < last_brightness <= 255:
-                self._last_brightness = last_brightness
+        if last_state is not None:
+            last_brightness = last_state.attributes.get(_ATTR_LAST_BRIGHTNESS)
+            if isinstance(last_brightness, int) and not isinstance(last_brightness, bool):
+                if 0 < last_brightness <= 255:
+                    self._last_brightness = last_brightness
+                    return
+
+        self._last_brightness = 255
 
 
 class BlueairLightEntity(BlueairRestoredBrightnessEntity):

--- a/custom_components/ha_blueair/light.py
+++ b/custom_components/ha_blueair/light.py
@@ -3,9 +3,7 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     LightEntity,
 )
-from homeassistant.components.light.const import (
-    ColorMode
-)
+from homeassistant.components.light.const import ColorMode
 import logging
 
 from .entity import BlueairEntity, async_setup_entry_helper
@@ -15,12 +13,16 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Blueair sensors from config entry."""
-    async_setup_entry_helper(hass, config_entry, async_add_entities,
+    async_setup_entry_helper(
+        hass,
+        config_entry,
+        async_add_entities,
         entity_classes=[
             BlueairLightEntity,
             BlueairMoodLightEntity,
             BlueairNightLightEntity,
-    ])
+        ],
+    )
 
 
 class BlueairLightEntity(BlueairEntity, LightEntity):
@@ -33,11 +35,15 @@ class BlueairLightEntity(BlueairEntity, LightEntity):
 
     def __init__(self, coordinator):
         super().__init__("LED Light", coordinator)
+        self._last_brightness = self.coordinator.brightness or 255
 
     @property
     def brightness(self) -> int | None:
         """Return the brightness of this light between 0..255."""
-        return self.coordinator.brightness
+        brightness = self.coordinator.brightness
+        if brightness:
+            self._last_brightness = brightness
+        return brightness
 
     @property
     def is_on(self) -> bool:
@@ -45,13 +51,16 @@ class BlueairLightEntity(BlueairEntity, LightEntity):
         return self.coordinator.brightness != 0
 
     async def async_turn_on(self, **kwargs):
-        desired_brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
+        desired_brightness = kwargs.get(ATTR_BRIGHTNESS, self._last_brightness)
+        if ATTR_BRIGHTNESS in kwargs:
+            self._last_brightness = desired_brightness
         await self.coordinator.set_brightness(desired_brightness)
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
         await self.coordinator.set_brightness(0)
         self.async_write_ha_state()
+
 
 class BlueairMoodLightEntity(BlueairEntity, LightEntity):
     _attr_color_mode = ColorMode.BRIGHTNESS
@@ -63,11 +72,15 @@ class BlueairMoodLightEntity(BlueairEntity, LightEntity):
 
     def __init__(self, coordinator):
         super().__init__("Mood Light", coordinator)
+        self._last_brightness = self.coordinator.mood_brightness or 255
 
     @property
     def brightness(self) -> int | None:
         """Return the brightness of this light between 0..255."""
-        return self.coordinator.mood_brightness
+        brightness = self.coordinator.mood_brightness
+        if brightness:
+            self._last_brightness = brightness
+        return brightness
 
     @property
     def is_on(self) -> bool:
@@ -75,7 +88,9 @@ class BlueairMoodLightEntity(BlueairEntity, LightEntity):
         return self.coordinator.mood_brightness_is_on
 
     async def async_turn_on(self, **kwargs):
-        desired_brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
+        desired_brightness = kwargs.get(ATTR_BRIGHTNESS, self._last_brightness)
+        if ATTR_BRIGHTNESS in kwargs:
+            self._last_brightness = desired_brightness
         await self.coordinator.set_mood_brightness(desired_brightness)
         self.async_write_ha_state()
 
@@ -94,11 +109,15 @@ class BlueairNightLightEntity(BlueairEntity, LightEntity):
 
     def __init__(self, coordinator):
         super().__init__("Night Light", coordinator)
+        self._last_brightness = self.coordinator.night_light_brightness or 255
 
     @property
     def brightness(self) -> int | None:
         """Return the brightness of this light between 0..255."""
-        return self.coordinator.night_light_brightness
+        brightness = self.coordinator.night_light_brightness
+        if brightness:
+            self._last_brightness = brightness
+        return brightness
 
     @property
     def is_on(self) -> bool:
@@ -106,7 +125,9 @@ class BlueairNightLightEntity(BlueairEntity, LightEntity):
         return self.coordinator.night_light_brightness_is_on
 
     async def async_turn_on(self, **kwargs):
-        desired_brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
+        desired_brightness = kwargs.get(ATTR_BRIGHTNESS, self._last_brightness)
+        if ATTR_BRIGHTNESS in kwargs:
+            self._last_brightness = desired_brightness
         await self.coordinator.set_night_light_brightness(desired_brightness)
         self.async_write_ha_state()
 

--- a/custom_components/ha_blueair/light.py
+++ b/custom_components/ha_blueair/light.py
@@ -4,11 +4,13 @@ from homeassistant.components.light import (
     LightEntity,
 )
 from homeassistant.components.light.const import ColorMode
+from homeassistant.helpers.restore_state import RestoreEntity
 import logging
 
 from .entity import BlueairEntity, async_setup_entry_helper
 
 _LOGGER = logging.getLogger(__name__)
+_ATTR_LAST_BRIGHTNESS = "last_brightness"
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -25,7 +27,28 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     )
 
 
-class BlueairLightEntity(BlueairEntity, LightEntity):
+class BlueairRestoredBrightnessEntity(BlueairEntity, LightEntity, RestoreEntity):
+    """Base light entity that retains brightness while the light is off."""
+
+    @property
+    def extra_state_attributes(self) -> dict[str, int]:
+        """Return the brightness used when the light is next turned on."""
+        return {_ATTR_LAST_BRIGHTNESS: self._last_brightness}
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the previous brightness after a Home Assistant restart."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is None or self.is_on:
+            return
+
+        last_brightness = last_state.attributes.get(_ATTR_LAST_BRIGHTNESS)
+        if isinstance(last_brightness, int) and not isinstance(last_brightness, bool):
+            if 0 < last_brightness <= 255:
+                self._last_brightness = last_brightness
+
+
+class BlueairLightEntity(BlueairRestoredBrightnessEntity):
     _attr_color_mode = ColorMode.BRIGHTNESS
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
@@ -62,7 +85,7 @@ class BlueairLightEntity(BlueairEntity, LightEntity):
         self.async_write_ha_state()
 
 
-class BlueairMoodLightEntity(BlueairEntity, LightEntity):
+class BlueairMoodLightEntity(BlueairRestoredBrightnessEntity):
     _attr_color_mode = ColorMode.BRIGHTNESS
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
@@ -99,7 +122,7 @@ class BlueairMoodLightEntity(BlueairEntity, LightEntity):
         self.async_write_ha_state()
 
 
-class BlueairNightLightEntity(BlueairEntity, LightEntity):
+class BlueairNightLightEntity(BlueairRestoredBrightnessEntity):
     _attr_color_mode = ColorMode.BRIGHTNESS
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 


### PR DESCRIPTION
Hello, thanks for the awesome work on this project! Last time I checked there was no mini restful implement, but I'm delighted to see it now! 

I have one minor nitpick, which is that the light exposed is set to 100% brightness whenever it is turned on. It does not recall the last set brightness, and on the mini restful 100% brightness is markedly not restful. :)

I have tested this PR on my home assistant setup and it works well and thought I'd offer to share. I only have the mini restful so I'm unable to test if this has unforeseen consequences elsewhere.